### PR TITLE
Restrict when to release locks going out of scope

### DIFF
--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -304,7 +304,10 @@ application instance.
 
 sub DESTROY {
   my $self = shift;
-  $self->unlock() if ($self->{LOCK_SET});
+  # We unlock only on the process that owns the lock.  Otherwise this
+  # might be a forked process that is exiting and shouldn't sweep
+  # under its parent's feet.
+  $self->unlock() if $self->{LOCK_SET} && $self->get_lock_pid() == $$;
 }
 
 

--- a/src/test/perl/lock-fork.t
+++ b/src/test/perl/lock-fork.t
@@ -1,0 +1,33 @@
+# -*- mode: cperl -*-
+use strict;
+use warnings;
+use Test::More;
+use CAF::Lock qw(FORCE_IF_STALE FORCE_ALWAYS);
+use Test::MockObject::Extends;
+
+use constant LOCK_TEST_DIR => "target/tests";
+use constant LOCK_TEST => LOCK_TEST_DIR . "/lock-fork";
+
+my $pid;
+
+my $mock = Test::MockObject::Extends->new("CAF::Lock");
+
+$mock->mock('unlock', 1);
+
+mkdir(LOCK_TEST_DIR);
+unlink(LOCK_TEST);
+
+my $lock=CAF::Lock->new(LOCK_TEST);
+
+$lock->set_lock();
+
+$lock=CAF::Lock->new(LOCK_TEST);
+
+$$++;
+
+$lock = undef;
+
+$mock->next_call();
+is($mock->next_call(), undef, "Lock is not released after forking");
+
+done_testing();


### PR DESCRIPTION
Fixes #6

Forked processes must release their locks explicitly.

Thanks to @ned21 and Gabor for the report and details.
