### PR TITLE
Test the lock-fork only if $$ is writeable

### DIFF
--- a/src/test/perl/lock-fork.t
+++ b/src/test/perl/lock-fork.t
@@ -8,6 +8,11 @@ use Test::MockObject::Extends;
 use constant LOCK_TEST_DIR => "target/tests";
 use constant LOCK_TEST => LOCK_TEST_DIR . "/lock-fork";
 
+eval {
+    $$++;
+    $$--;
+};
+plan skip_all => "Cannot manipulate PID" if $@;
 my $pid;
 
 my $mock = Test::MockObject::Extends->new("CAF::Lock");


### PR DESCRIPTION
On Perl 5.10 (RH6) $$ is read-only and the test crashes.  I have tested this
already on SL5, and the bug shows up on my Fedora before the patch and is
fixed after the patch.

And it's a corner case for a low-impact bug.

Fixes #6.
