### PR TITLE
Store manipulated files in the log object

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -175,6 +175,7 @@ sub close
         $cmd->execute();
         *$self->{LOG}->verbose ("Changes to ", *$self->{filename}, ":");
         *$self->{LOG}->report ($diff);
+
     }
 
     if (*$self->{save}) {
@@ -193,6 +194,9 @@ sub close
                                     " was not modified")
                 if *$self->{LOG};
         }
+    }
+    if (*$self->{LOG} && *$self->{LOG}->can('add_files')) {
+        *$self->{LOG}->add_files(*$self->{filename});
     }
     $self->SUPER::close();
     return $ret;

--- a/src/test/perl/test-caffilewriter.t
+++ b/src/test/perl/test-caffilewriter.t
@@ -35,6 +35,7 @@ sub init_test
 
 our $cmd;
 our $mock;
+our $app;
 
 BEGIN {
     $mock = Test::MockModule->new ("CAF::Process");
@@ -49,6 +50,7 @@ BEGIN {
                      $? = 0;
                      return 1;
                 });
+    $app = Test::MockModule->new ('CAF::Application');
 }
 
 use CAF::FileWriter;
@@ -167,5 +169,16 @@ $fh = CAF::FileWriter->open ($INC{"CAF/FileWriter.pm"}, log => $this_app);
 print $fh "hello world\n";
 $fh->close();
 is($report, 0, "Diff output is reported only with verbose");
+
+$app->mock('add_files', sub {
+           my ($self, @args) = @_;
+           $self->{FILES} = \@args;
+       });
+
+init_test();
+$fh = CAF::FileWriter->open ($INC{"CAF/FileWriter.pm"}, log => $this_app);
+$fh->close();
+is(scalar(@{$this_app->{FILES}}), 1,
+   "Files were recorded when the logger can add_files");
 
 done_testing();


### PR DESCRIPTION
Both CAF::FileWriter and CAF::FileEditor will inherit the new behaviour.

Closes #10

This is all the support we need on the CAF side to store, query and selectively clean up files.
