### PR TITLE
add a noAction() method to Object and FileWriter to return the noaction flag value

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -131,6 +131,7 @@ sub new
     *$self->{options}->{group} = $opts{group} if exists ($opts{group});
     *$self->{options}->{backup} = $opts{backup} if exists ($opts{backup});
     *$self->{save} = 1;
+    *$self->{NoAction} = $CAF::Object::NoAction;
     return bless ($self, $class);
 }
 
@@ -162,7 +163,7 @@ sub close
     my $self = shift;
     my ($str, $ret, $cmd, $diff);
 
-    if ($CAF::Object::NoAction) {
+    if ($self->noAction()) {
         $self->cancel();
     }
 
@@ -212,6 +213,20 @@ sub cancel
         *$self->{LOG}->verbose ("Not saving file ", *$self->{filename});
     }
     *$self->{save} = 0;
+}
+
+=pod
+
+=item noAction
+
+Returns the NoAction flag value (boolean)
+
+=cut
+
+sub noAction
+{
+    my $self = shift;
+    return *$self->{NoAction};
 }
 
 =pod

--- a/src/main/perl/Object.pm
+++ b/src/main/perl/Object.pm
@@ -82,12 +82,28 @@ sub new {
   my $self = {}; # here, it gives a reference on a hash
   bless $self, $class;
   if ($self->_initialize(@_)) {
+    # Initialize instance variable to class variable if not initializedin _initialize().
+    # A derived class which must define it differently must define it before.
+    $self->{NoAction} = $CAF::Object::NoAction if !defined($self->{NoAction});
     return $self;
   } else {
     throw_error("cannot instantiate class: $class", $ec->error || '');
     undef $self;
     return undef;
   }
+}
+
+
+=item noAction
+
+Returns the NoAction flag value (boolean)
+
+=cut
+
+sub noAction
+{
+    my $self = shift;
+    return $self->{NoAction};
 }
 
 

--- a/src/main/perl/Process.pm
+++ b/src/main/perl/Process.pm
@@ -122,7 +122,7 @@ sub _initialize
     }
 
 
-    $self->{NoAction} = $CAF::Object::NoAction && !$opts{keeps_state};
+    $self->{NoAction} = 0 if $opts{keeps_state};
 
     $self->{COMMAND} = $command;
 
@@ -153,7 +153,7 @@ sub execute
     my $self = shift;
 
     my $na = "E";
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
         $na = "Not e";
     }
     if ($self->{log}) {
@@ -165,7 +165,7 @@ sub execute
         }
         $self->{log}->verbose (join (" ", "Command options:", @opts));
     }
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
         return 0;
     }
     return LC::Process::execute ($self->{COMMAND}, %{$self->{OPTIONS}});
@@ -190,7 +190,7 @@ sub output
 				@{$self->{COMMAND}}))
 	if $self->{log};
 
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
 	return "";
     }
 
@@ -218,7 +218,7 @@ sub toutput
 				 "|with $timeout seconds of timeout"))
 	if $self->{log};
 
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
 	return "";
     }
     return LC::Process::toutput ($timeout, @{$self->{COMMAND}});
@@ -241,7 +241,7 @@ sub run
     $self->{log}->verbose (join (" ", "Running the command:",
 				 @{$self->{COMMAND}}))
 	if $self->{log};
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
 	 return 0;
     }
     return LC::Process::run (@{$self->{COMMAND}});
@@ -266,7 +266,7 @@ sub trun
 				 "|with $timeout seconds of timeout"))
 	if $self->{log};
 
-    if ($self->{NoAction}) {
+    if ($self->noAction()) {
 	 return 0;
     }
 


### PR DESCRIPTION
Also update Process to use this new method.

The rationale of this pull request is to provide a uniform way of retrieving the noaction flag value, whether the object is based on CAF::Object or CAF::FileWriter (which is not a CAF::Object).

A typical use case is demonstrated in `ncm-named` (https://github.com/quattor/configuration-modules-core/pull/243) to avoid printing an error message in unit tests when a file was not updated because of the noaction flag defined in the tests..
