### PR TITLE
Fix uninitialized warnings when running with --noaction

### DIFF
--- a/src/main/perl/Process.pm
+++ b/src/main/perl/Process.pm
@@ -307,6 +307,15 @@ sub setopts
     foreach my $i (qw(timeout stdin stderr stdout shell)) {
 	$self->{OPTIONS}->{$i} = $opts{$i} if exists($opts{$i});
     }
+
+    # Initialize stdout and stderr if they exist. Otherwise, NoAction
+    # runs will spill plenty of spurious uninitialized warnings.
+    foreach my $i (qw(stdout stderr)) {
+        if (exists($self->{OPTIONS}->{$i}) && ref($self->{OPTIONS}->{$i}) &&
+            !defined(${$self->{OPTIONS}->{$i}})) {
+            ${$self->{OPTIONS}->{$i}} = "";
+        }
+    }
 }
 
 1;

--- a/src/test/perl/test-cafprocess.t
+++ b/src/test/perl/test-cafprocess.t
@@ -95,6 +95,9 @@ $p->execute ();
 is ($opts{stdin}, "Something", "Option from creation is respected");
 is (${$opts{stdout}}, $str, "Correct stdout");
 ok (@$cmd == @$command, "The command got options appended");
+$str = undef;
+$p->setopts (stdout => \$str);
+is($str, "", "Stdout is initialized");
 # Test the NoAction flag
 $CAF::Object::NoAction = 1;
 init_test();


### PR DESCRIPTION
Fixes #25.

Thanks to @NZJourneyMan for the report.
