### PR TITLE
get rid of 'uninitialized value' warnings

### DIFF
--- a/src/main/perl/Reporter.pm
+++ b/src/main/perl/Reporter.pm
@@ -267,7 +267,7 @@ sub debug {
     return;
   }
 
-  if ($_REP_SETUP->{DEBUGLV} >= $debuglvl) {
+  if (defined($_REP_SETUP->{DEBUGLV}) && $_REP_SETUP->{DEBUGLV} >= $debuglvl) {
     $self->syslog ('debug', @_);
     return $self->report('[DEBUG] ',@_);
   }

--- a/src/main/perl/ReporterMany.pm
+++ b/src/main/perl/ReporterMany.pm
@@ -301,7 +301,7 @@ sub debug ($@) {
         return;
     }
 
-    if ($self->{DEBUGLV} >= $debuglvl) {
+    if (defined($self->{DEBUGLV}) && $self->{DEBUGLV} >= $debuglvl) {
         $self->syslog ('debug', @_);
         return $self->report('[DEBUG] ',@_);
     }


### PR DESCRIPTION
fixes https://github.com/quattor/CAF/issues/20 and https://github.com/quattor/ncm-ncd/issues/26
