### PR TITLE
Revert "Service OS flavour for mocking/unittests"

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -229,30 +229,6 @@ sub restart_solaris
     return $self->_logcmd(@cmd, @{$self->{services}});
 }
 
-# Determine the OS flavour. (Also allows mocking the flavour for unittests)
-sub os_flavour 
-{
-    my $flavour;
-    if ($^O eq 'linux') {
-        $flavour = "linux";
-        if (-x "/bin/systemctl") {
-            $flavour .= "_systemd";
-        } elsif (-x "/sbin/service") {
-             $flavour .= "_sysv";
-        } else {
-            die "Unsupported Linux version. Unable to run $AUTOLOAD";
-        }
-    } elsif ($^O eq 'solaris') {
-        $flavour = "solaris";
-    } else {
-        die "Unsupported operating system: $^O. Not running $AUTOLOAD";
-    }
-
-    if (! defined($flavour)) {
-        die "Undefined flavour for operating system: $^O. Not running $AUTOLOAD";
-    }
-    return $flavour
-}
 
 # Choose the correct variant for each daemon action.  All the
 # OS-dependent logic is here.  See perldoc perlsub for details on how
@@ -267,7 +243,20 @@ sub AUTOLOAD
     return if $called =~ m{DESTROY};
 
     $called =~ s{.*::}{};
-    $called .= "_" . os_flavour();
+
+    if ($^O eq 'linux') {
+        if (-x "/bin/systemctl") {
+            $called .= "_linux_systemd";
+        } elsif (-x "/sbin/service") {
+            $called .= "_linux_sysv";
+        } else {
+            die "Unsupported Linux version. Unable to run $AUTOLOAD";
+        }
+    } elsif ($^O eq 'solaris') {
+        $called .= "_solaris";
+    } else {
+        die "Unsupported operating system: $^O. Not running $AUTOLOAD";
+    }
 
     if ($self->can($called)) {
         # Run the expected method. This is ugly but it's the way to do

--- a/src/test/perl/service-autoload.t
+++ b/src/test/perl/service-autoload.t
@@ -4,10 +4,10 @@ use warnings;
 use Test::More;
 use Test::Quattor;
 use CAF::Service;
-use Test::MockModule;
 
-my $mock = Test::MockModule->new("CAF::Service");
-$mock->mock("os_flavour", "linux_systemd");
+if (! -f "/bin/systemctl" && ! -f "/sbin/service") {
+    plan skip_all => "No supported variants found";
+}
 
 =pod
 

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -4,7 +4,6 @@ use warnings;
 use Test::More;
 use Test::Quattor;
 use CAF::Service;
-use Test::MockModule;
 
 =pod
 
@@ -14,9 +13,10 @@ Test all methods for C<CAF::Service>
 
 =cut
 
-my $mock = Test::MockModule->new("CAF::Service");
-$mock->mock("os_flavour", "linux_systemd");
-
+# We forcefully choose one of the create_process implementations,
+# since we are not interested in the behaviour of AUTOLOAD at this
+# stage.
+*CAF::Service::create_process = \&CAF::Service::create_process_linux_systemd;
 
 my $srv = CAF::Service->new(['ntpd', 'sshd']);
 


### PR DESCRIPTION
Reverts quattor/CAF#44
