### PR TITLE
suppress redefine warning of change_hook redefinition

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -27,7 +27,8 @@ our @ISA = qw (IO::String);
 if ($^O eq 'linux'){
     # temporarily remove PATH environment
     # allows for 'use CAF::FileWriter' under -T without warnings
-    delete local $ENV{PATH};
+    local $ENV{PATH};
+    delete $ENV{PATH};
     if(CAF::Process->new(["/usr/sbin/selinuxenabled"])->run() && $? == 0) {
         no warnings 'redefine';
         *change_hook = sub {


### PR DESCRIPTION
gets rid of warning Subroutine CAF::FileWriter::change_hook redefined at /usr/lib/perl/CAF/FileWriter.pm line 45.
