### PR TITLE
Add reload functionality to CAF::Service

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -187,7 +187,7 @@ sub create_process_solaris
 
 # The restart, start and stop methods are identical on each Linux
 # variant.  We can generate them all in one go.
-foreach my $method (qw(start stop restart)) {
+foreach my $method (qw(start stop restart reload)) {
     no strict 'refs';
     *{"${method}_linux_sysv"} = sub {
         my $self = shift;
@@ -205,7 +205,7 @@ foreach my $method (qw(start stop restart)) {
         return $self->_logcmd("systemctl", $method, @{$self->{services}});
     };
 
-    next if $method eq 'restart';
+    next if $method eq 'restart'  || $method eq 'reload';
 
     *{"${method}_solaris"} = sub {
         my $self = shift;
@@ -230,8 +230,15 @@ sub restart_solaris
     return $self->_logcmd(@cmd, @{$self->{services}});
 }
 
+sub reload_solaris
+{
+    my $self = shift;
+
+    return $self->_logcmd(qw(svcadm -v refresh), @{$self->{services}});
+}
+
 # Determine the OS flavour. (Also allows mocking the flavour for unittests)
-sub os_flavour 
+sub os_flavour
 {
     my $flavour;
     if ($^O eq 'linux') {

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -21,7 +21,7 @@ $mock->mock("os_flavour", "linux_systemd");
 my $srv = CAF::Service->new(['ntpd', 'sshd']);
 
 
-foreach my $m (qw(start stop restart)) {
+foreach my $m (qw(start stop restart reload)) {
     my $method = "${m}_linux_systemd";
     $srv->$method();
     ok(get_command("systemctl $m ntpd sshd"), "systemctl $m works");
@@ -29,7 +29,7 @@ foreach my $m (qw(start stop restart)) {
 
 
 *CAF::Service::create_process = \&CAF::Service::create_process_linux_sysv;
-foreach my $m (qw(start stop restart)) {
+foreach my $m (qw(start stop restart reload)) {
     my $method = "${m}_linux_sysv";
     $srv->$method();
     ok(get_command("service ntpd $m"), "sysv $m works");
@@ -45,6 +45,10 @@ $srv->start_solaris();
 ok(get_command("svcadm -v enable -t ntpd sshd"), "svcadm enable/start works");
 $srv->stop_solaris();
 ok(get_command("svcadm -v disable -t ntpd sshd"), "svcadm disable/stop works");
+
+$srv->reload_solaris();
+ok(get_command('svcadm -v refresh ntpd sshd'),
+   "reload mapped to svcadm's refresh operation");
 
 $srv->{timeout} = 42;
 $srv->restart_solaris();


### PR DESCRIPTION
Sorry about the silent month.  Busy times.

So, this adds a `reload` method to CAF::Service.  Please note that on SysV hosts this may not be implemented, and therefore the operation will fail.  In Solaris `reload` is called `refresh`.
