### PR TITLE
Service: use .service name with systemctl by default 

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -202,8 +202,8 @@ foreach my $method (qw(start stop restart reload)) {
 
     *{"${method}_linux_systemd"} = sub {
         my $self = shift;
-
-        return $self->_logcmd("systemctl", $method, @{$self->{services}});
+        return $self->_logcmd("systemctl", $method, 
+                              map { m/\.(service|target)$/ ? $_ : "$_.service" } @{$self->{services}} );
     };
 
     next if $method eq 'restart'  || $method eq 'reload';

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -24,7 +24,7 @@ my $srv = CAF::Service->new(['ntpd', 'sshd']);
 foreach my $m (qw(start stop restart reload)) {
     my $method = "${m}_linux_systemd";
     $srv->$method();
-    ok(get_command("systemctl $m ntpd sshd"), "systemctl $m works");
+    ok(get_command("systemctl $m ntpd.service sshd.service"), "systemctl $m works");
 }
 
 


### PR DESCRIPTION
CAF::Service methods for sytemd should use the `.service` name by default (but allow .target if set in servicename)
