### PR TITLE
Service: set explicit service timeout instead of passing undef with sysv

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -135,6 +135,8 @@ sub _initialize
 
     $opts{sleep} = DEFAULT_SLEEP if(!exists($opts{sleep}));
 
+    $self->{log} = delete $opts{log};
+
     $self->{services} = $services;
     $self->{options} = \%opts;
     return SUCCESS;
@@ -148,13 +150,11 @@ sub _logcmd
 
     my $proc = $self->create_process(@cmd);
     $proc->execute();
-    my $logger = $self->{options}->{log};
     my $method = $? ? "error" : "verbose";
 
-    $logger->$method("Command ", join(" ", @_), " produced stdout: ",
+    $self->$method("Command ", join(" ", @_), " produced stdout: ",
                      "$proc->{OPTIONS}->{stdout} and stderr: ",
-                     $proc->{OPTIONS}->{stderr})
-        if $logger;
+                     $proc->{OPTIONS}->{stderr});
     return !$?;
 }
 
@@ -173,7 +173,7 @@ sub create_process_linux_sysv
     }
     
     my $proc = CAF::Process->new(\@cmd,
-                                 log => $self->{options}->{log},
+                                 log => $self->{log},
                                  timeout => $timeout,
                                  stdout => \my $stdout,
                                  stderr => \my $stderr);
@@ -186,7 +186,7 @@ sub create_process_linux_systemd
     my ($self, @cmd) = @_;
 
     my $proc = CAF::Process->new(\@cmd,
-                                 log => $self->{options}->{log},
+                                 log => $self->{log},
                                  stdout => \my $stdout,
                                  stderr => \my $stderr);
     return $proc;
@@ -199,7 +199,7 @@ sub create_process_solaris
     my ($self, @cmd) = @_;
 
     my $proc = CAF::Process->new(\@cmd,
-                                 log => $self->{options}->{log},
+                                 log => $self->{log},
                                  stdout => \my $stdout,
                                  stderr => \my $stderr);
     return $proc;


### PR DESCRIPTION
Deal with warnings like

```
[INFO] running component: metaconfig
---------------------------------------------------------
updated /etc/logstash-forwarder
changed mode(00640) of /etc/logstash-forwarder
Use of uninitialized value in concatenation (.) or string at /usr/lib/perl/CAF/Process.pm line 174.
Use of uninitialized value $timeout in addition (+) at /usr/lib/perl/LC/Process.pm line 668.
[INFO] configure on component metaconfig executed, 0 errors, 0 warnings
```
