### PR TITLE
Add TextRender usage documentation

### DIFF
--- a/TextRender.md
+++ b/TextRender.md
@@ -263,6 +263,45 @@ Individual elements are dealt with via `CCM/pan_element.tt`
 [%- END -%]
 ```
 
-`CCM::TextRender` has the `doublequote` element option is set to produce
+The `doublequote` element option is set to produce
 a doublequoted string if `data` is a string and the `truefalse` option to
 generate `true` or `false` value if `data` is a boolean.
+
+So the following is possible:
+
+An object template
+
+```pan
+object template format;
+
+"/a" = 1;
+"/b" = 1.5;
+"/c/t" = true;
+"/c/f" = false;
+"/d" = "test";
+```
+
+with
+
+
+```perl
+my $trd = EDG::WP4::CCM::TextRender(
+    'CCM/pan',
+    $config->getElement('/'),
+    element => {
+        doublequote => 1,
+        truefalse => 1,
+    },
+);
+print "$trd";
+```
+
+gives
+
+```
+"/a" = 1; # long
+"/b" = 1.5; # double
+"/c/f" = false; # boolean
+"/c/t" = true; # boolean
+"/d" = "test"; # string
+```

--- a/TextRender.md
+++ b/TextRender.md
@@ -1,0 +1,162 @@
+# TextRender
+
+Generating structured text is best done with [`CAF::TextRender`][caf_textrender_docs].
+This document guides through the usage and testing of `CAF::TextRender`.
+
+Using `ncm-metaconfig`, which is the metacomponent build around
+`CAF::TextRender`, is described [here][metaconfig].
+
+TODO add correct/final url
+
+[caf_textrender_docs]: http://docs-test-caf.readthedocs.org/en/latest/CAF/CAF::TextRender
+[metaconfig]: https://github.com/quattor/configuration-modules-core/Metaconfig.md
+
+# CAF::TextRender
+
+Basic usage has 2 main modes:
+ * generate text : the `CAF::TextRender` instance has auto-stringification
+
+    <!-- language: lang-perl -->
+        use CAF::TextRender;
+        my $module = 'mymodule';
+        my $trd = CAF::TextRender->new($module, $contents, log => $self);
+        print "$trd"; # stringification
+
+ * write text to file : get a `CAF::FileWriter` instance with text from `CAF::TextRender` instance
+
+    <!-- language: lang-perl -->
+        use CAF::TextRender;
+        $module = "mymodule";
+        $trd = CAF::TextRender->new($module, $contents, log => $self);
+        my $fh = $trd->filewriter('/some/path');
+        die "Problem rendering the text" if (!defined($fh));
+        $fh->close();
+
+Besides the logger, the 2 main parameters are the `module` and the `contents`.
+The contents is a hash-reference with the data that is used to generate
+the text (e.g. from a `$cfg->getElement('/some/pan/path')->getTree()`).
+
+The `module` is what defines how the text is generated.
+
+It is either one of the following reserved values 
+ * *json* (using `JSON::XS`)
+ * *yaml* (using `YAML::XS`), 
+ * *properties* (using `Config::Properties`), 
+ * *tiny* (using `Config::Tiny`),
+ * *general* (using `Config::General`)
+
+(The builtin modules can have issues with reproducability, e.g. ordering or a default timestamp.)
+
+Or, for any other value, `Template::Toolkit` (TT) is used,
+and the `module` then indicates the relative path of the template to use.
+The absolute path of the TT files is determined by 2 optional parameters:
+the absolute `includepath` (defaults to `/usr/share/templates/quattor`)
+shouldn't be modified, but the `relpath` (defaults to `metaconfig`) should.
+
+A module `mytest/main` with relpath `mycode` will use a
+TT file `/usr/share/templates/quattor/mycode/mytest/main.tt`.
+The `relpath` is important for creating the TT files: when the
+`INCLUDE` directive is used, TT searches starting from the `includepath`,
+so in this example the `main.tt` might look like
+
+```
+[% data.name %]
+[% INCLUDE 'shared/data' %]
+```
+
+which will look for the absolute file `/usr/share/templates/quattor/shared/data.tt`.
+
+`CAF::TextRender` does not allow you to include files from a directory lower then `relpath` (e.g. `module` `../cleverhack` will not work).
+
+## Template::Toolkit
+
+[`Template::Toolkit`][TT_home] is a templating framework 
+
+Example template
+```
+Hello [% world %]
+
+```
+
+with content a perl hashref
+
+```perl
+{ world => 'Quattor' }
+```
+
+will generate
+
+```
+$ perl -e 'use Template; my $tttext="Hello [% world %]\n"; Template->new()->process(\$tttext, { world => "Quattor" });'
+Hello Quattor
+```
+
+TODO minimal version
+
+[TT_home]: http://www.template-toolkit.org/index.html
+
+TODO add url with examples
+
+### Newline / chomp behaviour
+
+TT can easily generate unwanted/unneeded newlines.
+The [`chomp` behaviour][TT_whitespace_chomp] can be summarised as follows
+
+Name     |  Tag Modifier
+---------|--------------
+NONE     |       +
+ONE      |       -
+COLLAPSE |       =
+GREEDY   |       ~
+
+[TT_whitespace_chomp]: http://www.template-toolkit.org/docs/manual/Config.html#section_PRE_CHOMP_POST_CHOMP
+
+
+
+# Test::Quattor::RegexpTest
+
+Testing the generated text (and in particular the TT files used to generate it)
+can be done via regular expressions and e.g. the `like` method from `Test::More`.
+
+[`Test::Quattor::RegexpTest`][regexptest_docs] provides an easy way to do this.
+
+A `RegexpTest` is a text file with 3 blocks separated by a `---` marker.
+
+The first block is the description, the second block a list of flags (one per line)
+and the third block has all the regular expressions.
+
+An example RegexpTest looks like
+
+    Verify mycode
+    ---
+    ---
+    ^line 1
+    ^line 3
+
+with an empty flags block (using the defaults `ordered` and `multiline`).
+
+If we create a file `src/test/resources/rt_mycode` with this content, we can now test
+generated text against this RegexpTest using
+
+
+```perl
+use Test::Quattor::RegexpTest;
+use CAF::TextRender;
+my $module = 'mymodule';
+my $trd = CAF::TextRender->new($module, $contents, log => $self);
+my $rt = Test::Quattor::RegexpTest->new(
+    regexp => 'src/test/resources/rt_mycode',
+    text => "$trd",
+    );
+$rt->test();
+```
+
+With the default flags, each line is compiled as a multiline regular expression and matched against the text.
+The matches are also checked if they are ordered. In the example above `line 3` is expected to match in the text
+following `line 1`. But it does not need to be the next line (e.g. there could be a `line 2` in between).
+Each match is a test and each verification of the ordering also.
+
+TODO add correct/final url
+
+[regexptest_docs]: http://docs-test-maven-tools.readthedocs.org/en/latest/maven-tools/RegexpTest/
+

--- a/TextRender.md
+++ b/TextRender.md
@@ -3,7 +3,7 @@
 Generating structured text is best done with [`CAF::TextRender`][caf_textrender_docs].
 This document guides through the usage and testing of `CAF::TextRender`.
 
-Using `ncm-metaconfig`, which is the metacomponent build around
+Using `ncm-metaconfig`, which is the metacomponent built around
 `CAF::TextRender`, is described [here][metaconfig].
 
 TODO add correct/final url
@@ -16,24 +16,26 @@ TODO add correct/final url
 Basic usage has 2 main modes:
  * generate text : the `CAF::TextRender` instance has auto-stringification
 
-    <!-- language: lang-perl -->
-        use CAF::TextRender;
-        my $module = 'mymodule';
-        my $trd = CAF::TextRender->new($module, $contents, log => $self);
-        print "$trd"; # stringification
+```perl
+use CAF::TextRender;
+my $module = 'mymodule';
+my $trd = CAF::TextRender->new($module, $contents, log => $self);
+print "$trd"; # stringification
+```
 
  * write text to file : get a `CAF::FileWriter` instance with text from `CAF::TextRender` instance
 
-    <!-- language: lang-perl -->
-        use CAF::TextRender;
-        $module = "mymodule";
-        $trd = CAF::TextRender->new($module, $contents, log => $self);
-        my $fh = $trd->filewriter('/some/path');
-        die "Problem rendering the text" if (!defined($fh));
-        $fh->close();
+```perl
+use CAF::TextRender;
+$module = "mymodule";
+$trd = CAF::TextRender->new($module, $contents, log => $self);
+my $fh = $trd->filewriter('/some/path');
+die "Problem rendering the text" if (!defined($fh));
+$fh->close();
+```
 
 Besides the logger, the 2 main parameters are the `module` and the `contents`.
-The contents is a hash-reference with the data that is used to generate
+The `contents` is a hash-reference with the data that is used to generate
 the text (e.g. from a `$cfg->getElement('/some/pan/path')->getTree()`).
 
 The `module` is what defines how the text is generated.
@@ -91,11 +93,27 @@ $ perl -e 'use Template; my $tttext="Hello [% world %]\n"; Template->new()->proc
 Hello Quattor
 ```
 
-TODO minimal version
-
+Further information on TT:
+ * [A nice writeup of the basics of TT][TT_basics_pnce]
+ * [TT examples section][TT_home_examples]
+ * [Older TT PCmag article][TT_linuxmag_old] (but some examples are outdated)
+ * [ncm-metaconfig TT files][ncm_metaconfig_TT_subdir] (TT files are in the subdirectories)
+ 
 [TT_home]: http://www.template-toolkit.org/index.html
+[TT_home_examples]: http://www.template-toolkit.org/about.html#section_Examples
+[TT_basics_pnce]: http://www.physics.umd.edu/pnce/pcs-docs/WebDesign/tt_basics.html
+[TT_linuxmag_old]: http://www.stonehenge.com/merlyn/LinuxMag/col60.html
+[ncm_metaconfig_TT_subdir]: https://github.com/quattor/configuration-modules-core/tree/master/ncm-metaconfig/src/main/metaconfig
 
-TODO add url with examples
+### Minimal version
+
+As quattor supports `EL5` and because the templating framework is deeply integrated in e.g. `CCM`, the minimal
+required version of the TT framework is 2.18.
+
+This is a rather old version, with some notable missing VMethods compared to recent ones, in particular the scalar
+methods `.lower` and `.upper` do not work, one should use resp `FILTER lower` and `FILTER upper`.
+
+Value based unittests are essential to detect any differences across the supported OS.
 
 ### Newline / chomp behaviour
 
@@ -155,8 +173,6 @@ With the default flags, each line is compiled as a multiline regular expression 
 The matches are also checked if they are ordered. In the example above `line 3` is expected to match in the text
 following `line 1`. But it does not need to be the next line (e.g. there could be a `line 2` in between).
 Each match is a test and each verification of the ordering also.
-
-TODO add correct/final url
 
 [regexptest_docs]: http://docs-test-maven-tools.readthedocs.org/en/latest/maven-tools/RegexpTest/
 


### PR DESCRIPTION
This is the `CAF::TextRender` part of the tutorial given during the 19th workshop.