### PR TITLE
CAF::Process add missing execute() in "Piping in and out" pod section

### DIFF
--- a/src/main/perl/Process.pm
+++ b/src/main/perl/Process.pm
@@ -596,6 +596,7 @@ and need to get its output and error:
     my $proc = CAF::Process->new (["cat", "-"], stdin => $stdin,
                                   stdout => \$stdout
                                   stderr => \$stderr);
+    $proc->execute();
 
 And we'll have the command's standard output and error on $stdout and
 $stderr.


### PR DESCRIPTION
Fixes #78