### PR TITLE
Application export cfgfile option name

### DIFF
--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -15,7 +15,13 @@ use CAF::Log;
 use File::Basename;
 use POSIX;
 
-@ISA=qw(CAF::Reporter CAF::Object);
+@ISA = qw(CAF::Reporter CAF::Object Exporter);
+
+use Readonly;
+Readonly our $OPTION_CFGFILE => 'cfgfile';
+
+our @EXPORT    = qw();
+our @EXPORT_OK = qw($OPTION_CFGFILE);
 
 my $ec = LC::Exception::Context->new->will_store_all;
 
@@ -347,13 +353,18 @@ sub _initialize ($$@) {
   my $configfile=undef;
   my @args_tmp = @argv;
   my $arg;
+
+  my $cfgfile_standalone_pattern = '^(--'.$OPTION_CFGFILE.')$';
+  my $cfgfile_value_pattern = '^(--'.$OPTION_CFGFILE.'=(\S+))$';
   while ($arg=shift(@args_tmp)) {
     $help_request=1 if (($arg =~ m%^(-|--)help$%));
-    $configfile = shift (@args_tmp) if ($arg =~ m%^(--cfgfile)$%);
-    $configfile = $2 if ($arg =~ m%^(--cfgfile=(\S+))$%);
+
+    $configfile = shift (@args_tmp) if ($arg =~ m%$cfgfile_standalone_pattern%);
+    $configfile = $2 if ($arg =~ m%$cfgfile_value_pattern%);
   }
 
-  my %confvar=$self->{'CONFIG'}->varlist('^cfgfile$');
+  my $cfgfile_pattern = '^'.$OPTION_CFGFILE.'$';
+  my %confvar=$self->{'CONFIG'}->varlist($cfgfile_pattern);
   if (exists $confvar{'cfgfile'}) {
     $configfile=$self->option("cfgfile") unless (defined $configfile);
 

--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -321,7 +321,7 @@ sub _initialize ($$@) {
     });
 
     # initialise predefined options
-    $self->{'CONFIG'}->set($OPTION_CFGFILE, undef);
+    $self->{'CONFIG'}->define($OPTION_CFGFILE, {DEFAULT => undef});
 
     # add application-specific options
     unless ($self->_add_options()) {

--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -74,35 +74,26 @@ Applications can extend or overwrite the default methods.
 
 =over
 
-=cut
-  
-#------------------------------------------------------------
-#                      Public Methods/Functions
-#------------------------------------------------------------
-
-=pod
-
 =back
 
 =head2 Public methods
 
 =over 4
 
-=item name():string
+=item name(): string
 
 Return the application name (basename)
 
 =cut
 
 sub name ($) {
-  my $self = shift;
-  return $self->{'NAME'};
+    my $self = shift;
+    return $self->{'NAME'};
 }
-
 
 =pod
 
-=item version():string
+=item version(): string
 
 Returns the version number as defined in $self->{'VERSION'}, or
 <unknown> if not defined.
@@ -110,13 +101,13 @@ Returns the version number as defined in $self->{'VERSION'}, or
 =cut
 
 sub version ($) {
-  my $self = shift;
-  return defined $self->{'VERSION'} ? $self->{'VERSION'} : '<unknown>';
+    my $self = shift;
+    return defined $self->{'VERSION'} ? $self->{'VERSION'} : '<unknown>';
 }
 
 =pod
 
-=item hostname():string
+=item hostname(): string
 
 Returns the machine's hostname.
 
@@ -124,44 +115,39 @@ Returns the machine's hostname.
 
 
 sub hostname ($) {
-  my $self = shift;
-  return $self->{'HOSTNAME'};
+    my $self = shift;
+    return $self->{'HOSTNAME'};
 }
 
 =pod
 
-=item username():string
+=item username(): string
 
 Returns the name of the user.
 
 =cut
 
 sub username {
-  my $self = shift;
-  return $self->{'USERNAME'};
+    my $self = shift;
+    return $self->{'USERNAME'};
 }
-
 
 =pod
 
-=item option($opt):scalar|undef
+=item option($opt): scalar|undef
 
-prints give back the option value coming from the command line and/or
+Returns the option value coming from the command line and/or
 configuration file. Scalar can be a string, or a reference to a hash
 or an array containing the option's value. option() is a wrapper
 on top of AppConfig->get($opt).
 
 =cut
 
-
 sub option ($$) {
-  my ($self,$opt) = @_;
+    my ($self,$opt) = @_;
 
-  return $self->{'CONFIG'}->get($opt);
+    return $self->{'CONFIG'}->get($opt);
 }
-
-
-
 
 =pod
 
@@ -172,75 +158,78 @@ Prints the usage message of the command based on options and help text.
 =cut
 
 sub show_usage () {
-  my $self = shift;
-  # show the version
-  $self->show_version();
-  # show usage
-  print $self->{'USAGE'}."\n";
-  print "The following options are available:\n\n";
-  #
-  # now loop over the options, print out aliases, default values
-  # and types, and help text.
-  #
-  my $opt;
-  foreach $opt (sort keys %{$self->{'CFHELP'}}) {
-    # format is (option|alias1|alias2|..(!|((:|=)(s|f|i)(@|%)?))?)
-    # take everything into one regexp as faster.
-    #
-    if ($opt =~ /([^=:!|]+)((\|([^=:!|]+))*)(!|((:|=)(s|f|i)(@|%)?))?/) {
-      my ($optname,$aliases,$spec,$optional,$atom,$vect)=($1,$2,$5,$7,$8,$9);
-      my $str=' --'.$optname;
-      if (defined $aliases) {
-        $aliases =~ s%\|%, --%g;
-        $str .= $aliases;
-      }
-      unless (!defined $spec || $spec eq '!') {
-        # not a simple flag.
-        if ($atom eq 's') {
-          $str .='  <string>';
-        } elsif ($atom eq 'f'){
-          $str .='  <float>';
-        } elsif ($atom eq 'i'){
-          $str .='  <integer>';
-        }
-        if (defined $vect) {
-          if ($vect eq '@') {
-            $str .= ' (list)';
-          } elsif ($vect eq '%') {
-            $str .= ' (hash)';
-          }
-        }
-        if ($optional eq ':') {
-          $str .= ' (optional value)';
-        }
-        # any default value?
-        my $default=$self->{'CONFIG'}->get($optname);
-        if (defined $default) {
-          if (ref($default) eq '') { #string
-            $str .="\n\t(default: '".$default."')";
-          } elsif (ref($default) eq 'ARRAY' && scalar (@$default)) {
-            $str .="\n\t(default: '".join(', ',@{$default})."')";
-          } elsif (ref($default) eq 'HASH' && scalar (keys (%$default))) {
-            $str .="\n\t(default:\n";
-            foreach (keys(%$default)) {
-              $str .="\t\t$_ -> ".$default->{$_}."\n";
-            }
-            $str .="\t)";
-          }
-        }
-      }
-      # add help text.
-      $str .= "\n\t".$self->{'CFHELP'}{$opt}."\n";
-      print $str;
-    } else {
-      throw_error("cannot parse option: $opt");
-      return undef;
-    }
-  }
-  print "\n"; # nice last empty line
-  return SUCCESS;
-}
+    my $self = shift;
 
+    # show the version
+    $self->show_version();
+
+    # show usage
+    print $self->{'USAGE'}."\n";
+    print "The following options are available:\n\n";
+
+    # now loop over the options, print out aliases, default values
+    # and types, and help text.
+    my $opt;
+    foreach $opt (sort keys %{$self->{'CFHELP'}}) {
+        # format is (option|alias1|alias2|..(!|((:|=)(s|f|i)(@|%)?))?)
+        # take everything into one regexp as faster.
+        if ($opt =~ /([^=:!|]+)((\|([^=:!|]+))*)(!|((:|=)(s|f|i)(@|%)?))?/) {
+            my ($optname,$aliases,$spec,$optional,$atom,$vect) = ($1,$2,$5,$7,$8,$9);
+            my $str = ' --'.$optname;
+            if (defined $aliases) {
+                $aliases =~ s%\|%, --%g;
+                $str .= $aliases;
+            }
+            unless (!defined $spec || $spec eq '!') {
+                # not a simple flag.
+                if ($atom eq 's') {
+                    $str .= '  <string>';
+                } elsif ($atom eq 'f'){
+                    $str .= '  <float>';
+                } elsif ($atom eq 'i'){
+                    $str .= '  <integer>';
+                }
+
+                if (defined $vect) {
+                    if ($vect eq '@') {
+                        $str .= ' (list)';
+                    } elsif ($vect eq '%') {
+                        $str .= ' (hash)';
+                    }
+                }
+
+                if ($optional eq ':') {
+                    $str .= ' (optional value)';
+                }
+
+                # any default value?
+                my $default = $self->{'CONFIG'}->get($optname);
+                if (defined $default) {
+                    if (ref($default) eq '') { #string
+                        $str .= "\n\t(default: '".$default."')";
+                    } elsif (ref($default) eq 'ARRAY' && scalar (@$default)) {
+                        $str .= "\n\t(default: '".join(', ',@{$default})."')";
+                    } elsif (ref($default) eq 'HASH' && scalar (keys (%$default))) {
+                        $str .= "\n\t(default:\n";
+                        foreach (keys(%$default)) {
+                            $str .= "\t\t$_ -> ".$default->{$_}."\n";
+                        }
+                        $str .= "\t)";
+                    }
+                }
+            }
+
+            # add help text.
+            $str .= "\n\t".$self->{'CFHELP'}{$opt}."\n";
+            print $str;
+        } else {
+            throw_error("cannot parse option: $opt");
+            return undef;
+        }
+    }
+    print "\n"; # nice last empty line
+    return SUCCESS;
+}
 
 =pod
 
@@ -250,14 +239,11 @@ prints the version number of the Application.
 
 =cut
 
-
-
 sub show_version () {
-  my $self = shift;
-  print "This is ",$self->name()," version ",$self->version(),"\n";
-  return SUCCESS;
+    my $self = shift;
+    print "This is ", $self->name(), " version ", $self->version(), "\n";
+    return SUCCESS;
 }
-
 
 =pod
 
@@ -265,7 +251,7 @@ sub show_version () {
 
 to be overloaded by the application with application specific options.
 
-This function has to return a reference to an array. 
+This function has to return a reference to an array.
 Every element in the array must be a reference to a hash with the
 following structure:
 
@@ -287,13 +273,11 @@ see also _app_default_options()
 =cut
 
 sub app_options () {
-# to be implemented by derived class, if required
-  return [()];
+    # to be implemented by derived class, if required
+    return [()];
 }
 
-
-
-=pod 
+=pod
 
 =back
 
@@ -308,165 +292,141 @@ Initialize the Application.
 =cut
 
 sub _initialize ($$@) {
-  my ($self,$command,@argv) = @_;
+    my ($self, $command, @argv) = @_;
 
-  $self->{'NAME'} = basename($command);
+    $self->{'NAME'} = basename($command);
 
-  # who is the user
-  $self->{'USERNAME'} = (getpwuid($<))[0] || getlogin || undef;
-  # name of machine
-  my ($sysname,$nodename,$release,$version,$machine) = POSIX::uname();
-  $self->{'HOSTNAME'} = $nodename;
+    # who is the user
+    $self->{'USERNAME'} = (getpwuid($<))[0] || getlogin || undef;
+    # name of machine
+    my ($sysname,$nodename,$release,$version,$machine) = POSIX::uname();
+    $self->{'HOSTNAME'} = $nodename;
 
-  #
-  # instantiate default configuration options and values,
-  # as given by Application.pm and/or the Application,
-  # and pass them to AppConfig.
-  #
-  # defaults: no option arguments,
-  #           expand internal vars in cf file, but scream if
-  #             an embedded variable is not defined (EXPAND_WARN)
-  #           option values are 'undef'
-  #
-  $self->{'CONFIG'}= AppConfig->new({
-                                    PEDANTIC => 1, # really needed?
-                                    CASE => 0,
-                                    GLOBAL => {
-                                            DEFAULT  => undef,
-                                            ARGCOUNT => ARGCOUNT_NONE,
-                                            EXPAND   => EXPAND_VAR|EXPAND_WARN
-                                              }
-                                    });
-  #
-  # add application-specific options
-  #
-  unless ($self->_add_options()) {
-    throw_error('Cannot add options');
-    return undef;
-  }
-  #
-  # check if we have a config file to read or a --help request.
-  # parse it 'by hand' instead of using AppConfig twice
-  # for cmd line parsing
-  #
-  my $help_request=0;
-  my $configfile=undef;
-  my @args_tmp = @argv;
-  my $arg;
-
-  my $cfgfile_standalone_pattern = '^(--'.$OPTION_CFGFILE.')$';
-  my $cfgfile_value_pattern = '^(--'.$OPTION_CFGFILE.'=(\S+))$';
-  while ($arg=shift(@args_tmp)) {
-    $help_request=1 if (($arg =~ m%^(-|--)help$%));
-
-    $configfile = shift (@args_tmp) if ($arg =~ m%$cfgfile_standalone_pattern%);
-    $configfile = $2 if ($arg =~ m%$cfgfile_value_pattern%);
-  }
-
-  my $cfgfile_pattern = '^'.$OPTION_CFGFILE.'$';
-  my %confvar=$self->{'CONFIG'}->varlist($cfgfile_pattern);
-  if (exists $confvar{'cfgfile'}) {
-    $configfile=$self->option("cfgfile") unless (defined $configfile);
-
+    # instantiate default configuration options and values,
+    # as given by Application.pm and/or the Application,
+    # and pass them to AppConfig.
     #
-    if (defined $configfile) {
-      unless (-e $configfile) {
-        print STDERR "Warning: cannot read config file: $configfile, dropping.\n";
-      } else {
-        # read conf file options.
-        # Note that a 'cfgfile' option doesn't make
-        # any sense inside the cfgfile ;-)
-        unless ($self->{'CONFIG'}->file($configfile)) {
-          # exit if something is wrong according to AppConfig.
-          print STDERR "Problems parsing configuration file ".$configfile."\n";
-          exit(-1);
-          #        throw_error('problems reading configuration file: '.$configfile);
-          #        return undef;
+    # defaults: no option arguments,
+    #           expand internal vars in cf file, but scream if
+    #             an embedded variable is not defined (EXPAND_WARN)
+    #           option values are 'undef'
+    $self->{'CONFIG'}= AppConfig->new({
+        PEDANTIC => 1, # really needed?
+        CASE => 0,
+        GLOBAL => {
+            DEFAULT  => undef,
+            ARGCOUNT => ARGCOUNT_NONE,
+            EXPAND   => EXPAND_VAR|EXPAND_WARN
         }
-      }
-    }
-  }
-  #
-  # if there was a request for --help, go for it before
-  # getting command line opt values (for getting the current
-  # default values before overwriting them with cmd line opts)
-  #
-  if ($help_request) {
-    $self->show_usage();
-    exit (0);
-  }
-  #
-  # now read in cmd line options, which always have highest priority.
-  # (uses Getopt::Long)
-  #
-  unless ($self->{'CONFIG'}->getopt(\@argv)) {
-    # exit if something is wrong according to AppConfig.
-    # print STDERR "problems reading command line\n";
-    exit(-1);
-    # throw_error('problems reading command line options');
-    # return undef;
-  }
+    });
 
-  #
-  # now we have all options available!
-  # Process now common options.
-  #
-
-  #
-  # user asks for --version
-  #
-  if ($self->option('version')) {
-    $self->show_version();
-    exit (0);
-  }
-
-  #
-  # setup Reporter: verbose, quiet, debug
-  #
-  my $facility = undef;
-  my %vl = $self->{'CONFIG'}->varlist(".*");
-  if (exists $vl{'facility'}) {
-    $facility = $self->option('facility');
-  }
-
-  $self->setup_reporter($self->option('debug'),
-                        $self->option('quiet'),
-                        $self->option('verbose'),
-                        $facility);
-
-  #
-  # initialize log file if any.
-  #
-
-  my %logvar=$self->{'CONFIG'}->varlist('^logfile$');
-  if (exists $logvar{'logfile'}) {
-    my $logfile=$self->option("logfile");
-    if (defined $logfile) {
-      # log requested on $logfile. Try to instantiate it and attach
-      # it to the reporter.
-      my $logflags='w';
-      $logflags  = 'a' if (defined $self->{'LOG_APPEND'});
-      $logflags .= 't' if (defined $self->{'LOG_TSTAMP'});
-
-      $self->{'LOG'} = CAF::Log->new($logfile, $logflags);
-      unless (defined $self->{'LOG'}) {
-        $ec->rethrow_error;
+    # add application-specific options
+    unless ($self->_add_options()) {
+        throw_error('Cannot add options');
         return undef;
-        #
-        # the log file is to be activated inside the
-        # application itself using
-        # $self->set_report_logfile($self->{'LOG'})
-        #
-      }
     }
-  }
 
-  # all done!
-  return SUCCESS;
+    # check if we have a config file to read or a --help request.
+    # parse it 'by hand' instead of using AppConfig twice
+    # for cmd line parsing
+    my $help_request = 0;
+    my $configfile = undef;
+    my @args_tmp = @argv;
+    my $arg;
+
+    my $cfgfile_standalone_pattern = '^(--'.$OPTION_CFGFILE.')$';
+    my $cfgfile_value_pattern = '^(--'.$OPTION_CFGFILE.'=(\S+))$';
+    while ($arg = shift(@args_tmp)) {
+        $help_request=1 if (($arg =~ m%^(-|--)help$%));
+
+        $configfile = shift (@args_tmp) if ($arg =~ m%$cfgfile_standalone_pattern%);
+        $configfile = $2 if ($arg =~ m%$cfgfile_value_pattern%);
+    }
+
+    my $cfgfile_pattern = '^'.$OPTION_CFGFILE.'$';
+    my %confvar = $self->{'CONFIG'}->varlist($cfgfile_pattern);
+    if (exists $confvar{'cfgfile'}) {
+        $configfile=$self->option("cfgfile") unless (defined $configfile);
+
+        if (defined $configfile) {
+            unless (-e $configfile) {
+                print STDERR "Warning: cannot read config file: $configfile, dropping.\n";
+            } else {
+                # read conf file options.
+                # Note that a 'cfgfile' option doesn't make
+                # any sense inside the cfgfile ;-)
+                unless ($self->{'CONFIG'}->file($configfile)) {
+                    # exit if something is wrong according to AppConfig.
+                    print STDERR "Problems parsing configuration file ".$configfile."\n";
+                    exit(-1);
+                }
+            }
+        }
+    }
+
+    # if there was a request for --help, go for it before
+    # getting command line opt values (for getting the current
+    # default values before overwriting them with cmd line opts)
+    if ($help_request) {
+        $self->show_usage();
+        exit (0);
+    }
+
+    # now read in cmd line options, which always have highest priority.
+    # (uses Getopt::Long)
+    unless ($self->{'CONFIG'}->getopt(\@argv)) {
+        # exit if something is wrong according to AppConfig.
+        exit(-1);
+    }
+
+    # now we have all options available!
+    # Process now common options.
+
+    # user asks for --version
+    if ($self->option('version')) {
+        $self->show_version();
+        exit (0);
+    }
+
+    # setup Reporter: verbose, quiet, debug
+    my $facility = undef;
+    my %vl = $self->{'CONFIG'}->varlist(".*");
+    if (exists $vl{'facility'}) {
+        $facility = $self->option('facility');
+    }
+
+    $self->setup_reporter(
+        $self->option('debug'),
+        $self->option('quiet'),
+        $self->option('verbose'),
+        $facility
+        );
+
+    # initialize log file if any.
+    # the log file is to be activated inside the
+    # application itself using
+    #     $self->set_report_logfile($self->{'LOG'})
+    my %logvar = $self->{'CONFIG'}->varlist('^logfile$');
+    if (exists $logvar{'logfile'}) {
+        my $logfile=$self->option("logfile");
+        if (defined $logfile) {
+            # log requested on $logfile. Try to instantiate it and attach
+            # it to the reporter.
+            my $logflags = 'w';
+            $logflags  = 'a' if (defined $self->{'LOG_APPEND'});
+            $logflags .= 't' if (defined $self->{'LOG_TSTAMP'});
+
+            $self->{'LOG'} = CAF::Log->new($logfile, $logflags);
+            unless (defined $self->{'LOG'}) {
+                $ec->rethrow_error;
+                return undef;
+            }
+        }
+    }
+
+    # all done!
+    return SUCCESS;
 }
-
-
-
 
 
 =pod
@@ -492,27 +452,32 @@ specific code - see the 'example' file):
 
 =cut
 
-
 sub _app_default_options () {
 
-  my @app_array=(
-                 {NAME =>'help',
-                  HELP =>'displays this help message.'},
-                 {NAME =>'version',
-                  HELP =>'prints current version and exits.'},
-                 {NAME =>'verbose',
-                  HELP =>'print more details on operations.'},
-                 {NAME =>'debug=i' ,
-                  HELP =>'set the debugging level to <1..5>.'},
-                 {NAME =>'quiet',
-                  HELP =>'suppress application output to stdout.'}#,
-#                 {NAME =>'noaction',
-#                  HELP =>'do not actually perform operations.'},
-#                 {NAME =>'cfgfile=s',
-#                  HELP =>'configuration file name'}
-                );
+    my @app_array = (
+        {
+            NAME => 'help',
+            HELP => 'displays this help message.',
+        },
+        {
+            NAME => 'version',
+            HELP => 'prints current version and exits.',
+        },
+        {
+            NAME => 'verbose',
+            HELP => 'print more details on operations.',
+        },
+        {
+            NAME => 'debug=i',
+            HELP => 'set the debugging level to <1..5>.',
+        },
+        {
+            NAME => 'quiet',
+            HELP =>'suppress application output to stdout.',
+        },
+    );
 
-  return \@app_array;
+    return \@app_array;
 }
 
 
@@ -524,47 +489,42 @@ add options coming from _app_default_options() and app_options()
 
 =cut
 
-
 sub _add_options ($) {
-  my $self=shift;
+    my $self=shift;
 
+    my $opt_default_ref = $self->_app_default_options();
+    my $opt_app_ref = $self->app_options();
 
-  my $opt_default_ref=$self->_app_default_options();
-  my $opt_app_ref = $self->app_options();
+    my @opts = @{$opt_default_ref};
+    push (@opts, @{$opt_app_ref});
 
-  my @opts=@{$opt_default_ref};
-  push (@opts,@{$opt_app_ref});
+    my $opt;
+    foreach $opt (@opts) {
+        my $default=undef;
+        $default=$opt->{'DEFAULT'} if (defined $opt->{'DEFAULT'});
 
-  my $opt;
-  foreach $opt (@opts) {
-    my $default=undef;
-    $default=$opt->{'DEFAULT'} if (defined $opt->{'DEFAULT'});
+        # AppConfig doesn't return anything sensible - if an error is found,
+        # it just uses a 'warn'. A user defined function should be used here
+        # to trap the error..
 
-#
-# AppConfig doesn't return anything sensible - if an error is found,
-# it just uses a 'warn'. A user defined function should be used here
-# to trap the error..
-#
+        $self->{'CONFIG'}->define(
+            $opt->{'NAME'},
+            {
+                DEFAULT => $default,
+            });
 
-    $self->{'CONFIG'}->define($opt->{'NAME'},{DEFAULT=>$default});
+        # setup help text for --help
+        $self->{'CFHELP'}{$opt->{'NAME'}}=$opt->{'HELP'};
 
-#    unless ($self->{'CONFIG'}->define($opt->{'NAME'},{DEFAULT=>$default})) {
-#      throw_error("error in application configuration: ".$opt->{'NAME'});
-#      return undef;
-#    }
-    #
-    # setup help text for --help
-    #
-    $self->{'CFHELP'}{$opt->{'NAME'}}=$opt->{'HELP'};
-
-    # possible extension: don't allow options starting with 'no..'
-  }
-  return SUCCESS;
+        # possible extension: don't allow options starting with 'no..'
+    }
+    return SUCCESS;
 }
 
 
 END {
     # report all stored warnings
+    # TODO why not errors too?
     foreach my $warning ($ec->warnings) {
         warn("[WARN] $warning");
     }
@@ -578,4 +538,4 @@ END {
 
 =cut
 
-1; ## END ##
+1;

--- a/src/test/perl/test-cafapplication.t
+++ b/src/test/perl/test-cafapplication.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Test::MockModule;
+use CAF::Application qw($OPTION_CFGFILE);
+
+
+is($OPTION_CFGFILE, 'cfgfile', 
+   "Magic configfile option name $OPTION_CFGFILE");
+
+my $def_cfgfile = '/doesnotexist/apptest.cfg';
+my $def_value = 'mydefault';
+
+my $mock = Test::MockModule->new('CAF::Application');
+$mock->mock('app_options', sub {
+    return [
+        {
+            NAME => "$OPTION_CFGFILE=s",
+            DEFAULT => $def_cfgfile,
+            HELP => 'Config file for test app',
+        },
+        {
+            NAME => 'myoption=s',
+            DEFAULT => $def_value,
+            HELP => 'A very useful option',
+        },
+        ];
+});
+
+my $app = CAF::Application->new('myname');
+isa_ok($app, 'CAF::Application', 'A CAF::Application instance');
+is($app->{NAME}, 'myname', 'NAME attribute set');
+
+# pick up the default 
+ok(! -f $def_cfgfile, "No default configfile $def_cfgfile found");
+is($app->option($OPTION_CFGFILE), $def_cfgfile, 
+   "Default config file location $def_cfgfile");
+is($app->option('myoption'), $def_value, 
+   "Default myoption value");
+
+# use actual cfgfile
+my $cfgfile = 'src/test/resources/apptest.cfg';
+my $value = 'myvalue';
+
+my $newapp = CAF::Application->new('myname', "--$OPTION_CFGFILE", $cfgfile);
+isa_ok($newapp, 'CAF::Application', 'A CAF::Application instance');
+
+ok(-f $cfgfile, "configfile $cfgfile found");
+is($newapp->option($OPTION_CFGFILE), $cfgfile, 
+   "Specified config file location $cfgfile");
+is($newapp->option('myoption'), $value, 
+   "myoption value from configfile");
+
+done_testing();

--- a/src/test/perl/test-cafapplication.t
+++ b/src/test/perl/test-cafapplication.t
@@ -6,7 +6,7 @@ use Test::MockModule;
 use CAF::Application qw($OPTION_CFGFILE);
 
 
-is($OPTION_CFGFILE, 'cfgfile', 
+is($OPTION_CFGFILE, 'cfgfile',
    "Magic configfile option name $OPTION_CFGFILE");
 
 my $def_cfgfile = '/doesnotexist/apptest.cfg';
@@ -32,24 +32,35 @@ my $app = CAF::Application->new('myname');
 isa_ok($app, 'CAF::Application', 'A CAF::Application instance');
 is($app->{NAME}, 'myname', 'NAME attribute set');
 
-# pick up the default 
+# pick up the default
 ok(! -f $def_cfgfile, "No default configfile $def_cfgfile found");
-is($app->option($OPTION_CFGFILE), $def_cfgfile, 
+is($app->option($OPTION_CFGFILE), $def_cfgfile,
    "Default config file location $def_cfgfile");
-is($app->option('myoption'), $def_value, 
+is($app->option('myoption'), $def_value,
    "Default myoption value");
 
 # use actual cfgfile
 my $cfgfile = 'src/test/resources/apptest.cfg';
 my $value = 'myvalue';
 
+# 1st format --cfgile path/tofile
 my $newapp = CAF::Application->new('myname', "--$OPTION_CFGFILE", $cfgfile);
 isa_ok($newapp, 'CAF::Application', 'A CAF::Application instance');
 
 ok(-f $cfgfile, "configfile $cfgfile found");
-is($newapp->option($OPTION_CFGFILE), $cfgfile, 
-   "Specified config file location $cfgfile");
-is($newapp->option('myoption'), $value, 
+is($newapp->option($OPTION_CFGFILE), $cfgfile,
+   "Specified config file location $cfgfile via --cfgile path/tofile");
+is($newapp->option('myoption'), $value,
    "myoption value from configfile");
+
+# 2nd format --cfgile=path/tofile
+my $newapp2 = CAF::Application->new('myname', "--$OPTION_CFGFILE=$cfgfile");
+isa_ok($newapp2, 'CAF::Application', 'A CAF::Application instance');
+
+is($newapp2->option($OPTION_CFGFILE), $cfgfile,
+   "Specified config file location $cfgfile --cfgile=path/tofile");
+is($newapp2->option('myoption'), $value,
+   "myoption value from configfile (2nd format)");
+
 
 done_testing();

--- a/src/test/resources/apptest.cfg
+++ b/src/test/resources/apptest.cfg
@@ -1,0 +1,2 @@
+myoption myvalue
+


### PR DESCRIPTION
Export the `cfgfile` option name as readonly `$OPTION_CFGFILE` (and use it internally in `CAF::Application`), mainly to prevent typos.