### PR TITLE
CAF::Application: fix 'Warning: cannot read config file: 0' message

### DIFF
--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -321,7 +321,7 @@ sub _initialize ($$@) {
     });
 
     # initialise predefined options
-    $self->{'CONFIG'}->define($OPTION_CFGFILE, {DEFAULT => undef});
+    $self->{'CONFIG'}->define($OPTION_CFGFILE, {ARGCOUNT => ARGCOUNT_ONE});
 
     # add application-specific options
     unless ($self->_add_options()) {

--- a/src/test/perl/test-cafapplication.t
+++ b/src/test/perl/test-cafapplication.t
@@ -9,6 +9,14 @@ use CAF::Application qw($OPTION_CFGFILE);
 is($OPTION_CFGFILE, 'cfgfile',
    "Magic configfile option name $OPTION_CFGFILE");
 
+# test predefined options
+my $defapp = CAF::Application->new('mydefname');
+isa_ok($defapp, 'CAF::Application', 'A CAF::Application instance');
+is($defapp->{NAME}, 'mydefname', 'NAME attribute set');
+
+ok(! defined($defapp->option($OPTION_CFGFILE)), "OPTION_CFGFILE is undef by default");
+
+# mock an application
 my $def_cfgfile = '/doesnotexist/apptest.cfg';
 my $def_value = 'mydefault';
 


### PR DESCRIPTION
fix `Warning: cannot read config file: 0` message when no `OPTION_CFGFILE` is set by application (e.g. ncm-query). this bug was introduced with #91
explanation: `GLOBAL` sets `ARGCOUNT_NONE`, but `->get(option)` will force a boolean as returned value, thus `undef` becomes `0`, and the cfgfile `0` is searched during `_initialize`.
