### PR TITLE
FileEditor: support add_after_newline in add_or_replace_lines method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.42</version>
+    <version>1.44</version>
     <relativePath />
   </parent>
   <licenses>

--- a/src/test/perl/test-caffileeditor.t
+++ b/src/test/perl/test-caffileeditor.t
@@ -7,7 +7,9 @@ use testapp;
 use CAF::FileEditor;
 use Test::More;
 use Carp qw(confess);
-our $filename = `mktemp`;
+
+our $filename = `mktemp --tmpdir=target`;
+
 use constant TEXT => <<EOF;
 En un lugar de La Mancha, de cuyo nombre no quiero acordarme
 no ha tiempo que vivía un hidalgo de los de lanza en astillero...

--- a/src/test/perl/test-caffileeditor_add_or_replace.t
+++ b/src/test/perl/test-caffileeditor_add_or_replace.t
@@ -5,16 +5,17 @@ use FindBin qw($Bin);
 use lib "$Bin/", "$Bin/..", "$Bin/../../perl-LC";
 use testapp;
 use CAF::FileEditor;
+use Test::Quattor::Object;
 use Test::More;
 use Carp qw(confess);
 use Fcntl qw(:seek);
 
-my $filename = `mktemp`;
-
+my $filename = `mktemp --tmpdir=target`;
 chomp($filename);
 
 my ($log, $str);
 my $this_app = testapp->new ($0, qw (--verbose));
+my $obj = Test::Quattor::Object->new();
 
 $SIG{__DIE__} = \&confess;
 
@@ -24,40 +25,56 @@ $SIG{__DIE__} = \&confess;
 };
 
 open ($log, ">", \$str);
-my $fh = CAF::FileEditor->new ($filename);
+my $fh = CAF::FileEditor->new ($filename, log => $obj);
 
 # begin/end tests for humans
-$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'END1', ENDING_OF_FILE);
-like("$fh", qr/END1$/, 'Initial ending using predefined constants');
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'END1a', ENDING_OF_FILE);
+like("$fh", qr/END1a$/, 'Initial ending using predefined constants');
 
 $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'BEGIN1', BEGINNING_OF_FILE);
 like("$fh", qr/^BEGIN1/, 'Initial beginning using predefined constants');
 
-is("$fh", "BEGIN1END1", "Begin and end added");
+# no newlines here because the BEGIN is inserted after the END is inserted
+is("$fh", "BEGIN1END1a", "Begin and end added");
+
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'END1', ENDING_OF_FILE);
+like("$fh", qr/END1a\nEND1$/, 'New ending using predefined constants, newline is inserted');
+is("$fh", "BEGIN1END1a\nEND1", "Begin and 2 ends added");
 
 # expert mode
+# inserting at begin of text requires no disabling of add_after_newline
 $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'begin2', SEEK_SET);
 like("$fh", qr/^begin2BEGIN1/, 'Add to begin using whence SET (default offset)');
 
-$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'end2', SEEK_END);
+# disable add_after_newline
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'end2', SEEK_END, undef, 0);
 like("$fh", qr/END1end2$/, 'Add to end using whence END (default offset)');
 
-is("$fh", "begin2BEGIN1END1end2", "Begin and end added part 2");
+is("$fh", "begin2BEGIN1END1a\nEND1end2", "Begin and end added part 2");
 
 # go to pos 5
-$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'Begin3', SEEK_SET, 5);
+# disable add_after_newline
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'Begin3', SEEK_SET, 5, 0);
 like("$fh", qr/^beginBegin3/, 'Add to begin using whence SET with offset');
 
-is("$fh", "beginBegin32BEGIN1END1end2", "Begin and end added part 3");
+is("$fh", "beginBegin32BEGIN1END1a\nEND1end2", "Begin and end added part 3 w/o add_after_newline");
+
+# with add_after_newline enabled
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'Begin3b', SEEK_SET, 5);
+like("$fh", qr/^begin\nBegin3b/, 'Add to begin using whence SET with offset with add_after_newline');
+
+is("$fh", "begin\nBegin3bBegin32BEGIN1END1a\nEND1end2", "Begin and end added part 3");
+
 
 # ok, let the bizare stuff begin
-# go to position 5 from the beginning
-$fh->seek(5, SEEK_SET);
+# go to position 6 from the beginning (after newline)
+$fh->seek(6, SEEK_SET);
 # add to the current position with an extra offset of 5
-$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'bEgIn4', SEEK_CUR, 5);
-like("$fh", qr/^beginBeginbEgIn4/, 'CUR whence with offset 5 (after seek 5)');
+# disable add_after_newline
+$fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'bEgIn4', SEEK_CUR, 5, 0);
+like("$fh", qr/^begin\nBeginbEgIn4/, 'CUR whence with offset 5 (after seek 5)');
 
-is("$fh", "beginBeginbEgIn432BEGIN1END1end2", "Begin and end added part 4");
+is("$fh", "begin\nBeginbEgIn43bBegin32BEGIN1END1a\nEND1end2", "Begin and end added part 4");
 
 # offset with SEEK_END
 my $origlength=length "$fh";
@@ -67,7 +84,8 @@ like("$fh", qr/END1end2\0\0\0$/, 'Seek beyond end should pad (text match)');
 
 $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'End3', SEEK_END);
 $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, 'eNd4', SEEK_END, 3);
-like("$fh", qr/End3\0\0\0eNd4$/, 'Add to end using whence END with offset part 3 and 4');
+# add_after_newline, newline is added after the padding
+like("$fh", qr/End3\0\0\0\neNd4$/, 'Add to end using whence END with offset part 3 and 4');
 
 
 $fh->cancel();
@@ -91,7 +109,7 @@ $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, "tsjoelala\n", SEEK_SET, $end);
 like("$fh", qr/# tsjoelala tsjoelala\ntsjoelala\nwe goan hem/, 'Insert text after header');
 
 my ($before, $after) = $fh->get_all_positions(qr{^tsjoelala.*$}m);
-# ok, $after (and $before) is a reference to an array; 
+# ok, $after (and $before) is a reference to an array;
 # if you pass it instead of eg $after->[0], you pass a very big number,
 # creating a very big string
 $fh->add_or_replace_lines(qr/xxx/, qr/yyy/, "tsjoelala\n", SEEK_SET, $after->[0]);

--- a/src/test/perl/test-caffileeditor_positions.t
+++ b/src/test/perl/test-caffileeditor_positions.t
@@ -9,7 +9,7 @@ use Test::More;
 use Carp qw(confess);
 use Fcntl qw(:seek);
 
-my $filename = `mktemp`;
+my $filename = `mktemp --tmpdir=target`;
 
 chomp($filename);
 


### PR DESCRIPTION
Fixes #79

As stated in the issue, this is backwards incompatible. Anyone/anything relying of the old behaviour that inserting a new line of text in the middle of existing text should modify their code.
