### PR TITLE
FileWriter: disable chatty LC::Check by default unless NoAction

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -214,7 +214,15 @@ sub close
         *$self->{save} = 0;
         $str = *$self->{buf};
         *$self->{options}->{contents} = $$str;
-        $ret = LC::Check::file (*$self->{filename}, %{*$self->{options}});
+
+        my %cf_opts = %{*$self->{options}};
+        if(! exists($cf_opts{silent})) {
+            # make sure LC::Check::file is silent unless in noaction mode
+            # (or when explicitly set via silent option)
+            $cf_opts{silent} = *$self->{options}->{noaction} ? 0 : 1
+        }
+
+        $ret = LC::Check::file (*$self->{filename}, %cf_opts);
         # Restore the SELinux context in case of modifications.
         if ($ret) {
             $self->change_hook();

--- a/src/test/perl/test-caffileeditor.t
+++ b/src/test/perl/test-caffileeditor.t
@@ -68,6 +68,7 @@ is_deeply(\%opts, {
     mtime => 1234567,
     contents => TEXT,
     noaction => 0,
+    silent => 1,
 }, "options set in new(), derived noaction and current contents are passed to LC (via parent filewriter)");
 
 is(*$fh->{filename}, $filename, "The object stores its parent's attributes");


### PR DESCRIPTION
Get rid of pesky `updated /path/to/file` messages that are not logged anyway, and only pollute stdout.
It's still enabled when running with `--noaction`, since it might indicate what the application is modifying (and thus might be considered useful).
Requires https://github.com/quattor/ncm-ncd/pull/88 and https://github.com/quattor/ncm-cdispd/pull/42
