### PR TITLE
Service: support subclassing

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -154,9 +154,9 @@ sub _logcmd
     $proc->execute();
     my $method = $? ? "error" : "verbose";
 
-    $self->$method("Command ", join(" ", @_), " produced stdout: ",
-                     "$proc->{OPTIONS}->{stdout} and stderr: ",
-                     $proc->{OPTIONS}->{stderr});
+    $self->$method("Command ", join(" ", @cmd), " produced stdout: ",
+                     ${$proc->{OPTIONS}->{stdout}}, " and stderr: ",
+                     ${$proc->{OPTIONS}->{stderr}});
     return !$?;
 }
 

--- a/src/test/perl/modules/myservice.pm
+++ b/src/test/perl/modules/myservice.pm
@@ -1,0 +1,23 @@
+package myservice;
+
+use strict;
+use warnings;
+
+use CAF::Service qw(__make_method FLAVOURS);
+
+our $AUTOLOAD;
+use parent qw(CAF::Service);
+
+sub _initialize {
+    my ($self, %opts) = @_;
+    return $self->SUPER::_initialize(['myservice'], %opts);
+}
+
+my $method = 'init';
+foreach my $flavour (FLAVOURS) {
+    no strict 'refs';
+    *{"${method}_${flavour}"} = __make_method($method, $flavour);
+    use strict 'refs';
+}
+
+1;

--- a/src/test/perl/modules/myservice.pm
+++ b/src/test/perl/modules/myservice.pm
@@ -3,6 +3,8 @@ package myservice;
 use strict;
 use warnings;
 
+use Test::More;
+
 use CAF::Service qw(__make_method FLAVOURS);
 
 our $AUTOLOAD;
@@ -13,11 +15,23 @@ sub _initialize {
     return $self->SUPER::_initialize(['myservice'], %opts);
 }
 
+# subclass new autoloaded magic
 my $method = 'init';
 foreach my $flavour (FLAVOURS) {
     no strict 'refs';
     *{"${method}_${flavour}"} = __make_method($method, $flavour);
     use strict 'refs';
+}
+
+# subclass existing autloaded method
+sub stop
+{
+    my ($self, @args) = @_;
+
+    diag 'myservice stop called';
+    $self->{mystop} = 1;
+
+    return $self->SUPER::stop(@args);
 }
 
 1;

--- a/src/test/perl/modules/myservice.pm
+++ b/src/test/perl/modules/myservice.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Test::More;
 
-use CAF::Service qw(__make_method FLAVOURS);
+use CAF::Service qw(__make_method @FLAVOURS);
 
 our $AUTOLOAD;
 use parent qw(CAF::Service);
@@ -17,7 +17,7 @@ sub _initialize {
 
 # subclass new autoloaded magic
 my $method = 'init';
-foreach my $flavour (FLAVOURS) {
+foreach my $flavour (@FLAVOURS) {
     no strict 'refs';
     *{"${method}_${flavour}"} = __make_method($method, $flavour);
     use strict 'refs';

--- a/src/test/perl/service-autoload.t
+++ b/src/test/perl/service-autoload.t
@@ -2,12 +2,22 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Quattor;
 use CAF::Service;
 use Test::MockModule;
 
+# do not use Test::Quattor for this test
+
 my $mock = Test::MockModule->new("CAF::Service");
 $mock->mock("os_flavour", "linux_systemd");
+
+# CAF::Service _logcmd uses execute()
+my $command;
+my $mockp = Test::MockModule->new('CAF::Process');
+$mockp->mock('execute', sub {
+    my $self = shift;
+    $command = join(" ", @{$self->{COMMAND}});
+    return 1;
+});
 
 =pod
 
@@ -21,7 +31,7 @@ my $srv = CAF::Service->new(['ntpd']);
 
 is(eval{$srv->restart();1;}, 1, "Restart is generated dynamically")
     or diag $@;
-can_ok($srv, "restart");
+ok(! $srv->can("restart"), 'After AUTOLOADING, the method is not added to the namespace (always re-AUTOLOADed)');
 is(eval{$srv->lkjhljh();1;}, undef, "Stupid method still fails");
 
 done_testing();

--- a/src/test/perl/service-subclass.t
+++ b/src/test/perl/service-subclass.t
@@ -64,4 +64,17 @@ foreach my $m (qw(start stop restart reload init)) {
 # for stop, the subclassed stop should have been called
 ok($srv->{mystop}, 'Subclassed stop was called');
 
+=pod
+
+=head2 Test logged message by _logcmd
+
+=cut
+
+my $msg;
+$mocks->mock('verbose', sub { shift; $msg=join('', @_); });
+$srv->start();
+is($command, "service myservice start", "subclassed service myservice start pt2");
+is($msg, 'Command service myservice start produced stdout:  and stderr: ',
+   "_logcmd created expected log message");
+
 done_testing();

--- a/src/test/perl/service-subclass.t
+++ b/src/test/perl/service-subclass.t
@@ -61,4 +61,7 @@ foreach my $m (qw(start stop restart reload init)) {
     is($command, "service myservice $m", "subclassed service myservice $m works");
 }
 
+# for stop, the subclassed stop should have been called
+ok($srv->{mystop}, 'Subclassed stop was called');
+
 done_testing();

--- a/src/test/perl/service-subclass.t
+++ b/src/test/perl/service-subclass.t
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Test::MockModule;
+use CAF::Service qw(FLAVOURS);
+use FindBin qw($Bin);
+use lib "$Bin/modules";
+
+use myservice;
+
+use Test::Quattor::Object;
+
+#TODO: fixed in newer buildtools
+
+# Cannot use Test::Quattor, as it calls 
+# set_service_variant, and it overrides the AUTOLOAD
+
+# CAF::Service _logcmd uses execute()
+my $command;
+my $mockp = Test::MockModule->new('CAF::Process');
+$mockp->mock('execute', sub { 
+    my $self = shift;
+    $command = join(" ", @{$self->{COMMAND}});
+    return 1;
+});
+
+my $mocks = Test::MockModule->new('CAF::Service');
+$mocks->mock('os_flavour', 'linux_sysv');
+
+
+my $obj = Test::Quattor::Object->new();
+
+my $srv = myservice->new(log=>$obj);
+
+=head2 Test methods
+
+Test avaliable methods
+
+=cut
+
+foreach my $m (qw(start stop restart reload init)) {
+    foreach my $fl (FLAVOURS) {
+        my $method = "${m}_${fl}";
+        diag "can $method";
+        ok($srv->can($method), "Method $method found");
+    }
+}
+
+=pod
+
+=head2 Test systemd
+
+Test all methods + custom init for C<CAF::Service> for linux_sysv
+
+=cut
+
+foreach my $m (qw(start stop restart reload init)) {
+    diag "method $m";
+    $srv->$m();
+    is($command, "service myservice $m", "subclassed service myservice $m works");
+}
+
+done_testing();

--- a/src/test/perl/service-subclass.t
+++ b/src/test/perl/service-subclass.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 
 use Test::MockModule;
-use CAF::Service qw(FLAVOURS);
+use CAF::Service qw(@FLAVOURS);
 use FindBin qw($Bin);
 use lib "$Bin/modules";
 
@@ -13,13 +13,13 @@ use Test::Quattor::Object;
 
 #TODO: fixed in newer buildtools
 
-# Cannot use Test::Quattor, as it calls 
+# Cannot use Test::Quattor, as it calls
 # set_service_variant, and it overrides the AUTOLOAD
 
 # CAF::Service _logcmd uses execute()
 my $command;
 my $mockp = Test::MockModule->new('CAF::Process');
-$mockp->mock('execute', sub { 
+$mockp->mock('execute', sub {
     my $self = shift;
     $command = join(" ", @{$self->{COMMAND}});
     return 1;
@@ -40,7 +40,7 @@ Test avaliable methods
 =cut
 
 foreach my $m (qw(start stop restart reload init)) {
-    foreach my $fl (FLAVOURS) {
+    foreach my $fl (@FLAVOURS) {
         my $method = "${m}_${fl}";
         diag "can $method";
         ok($srv->can($method), "Method $method found");


### PR DESCRIPTION
Make `CAF::Service` a possible parent class for component specific services.
(E.g. https://github.com/quattor/configuration-modules-core/pull/620)

Fixes quattor/configuration-modules-core#608