### PR TITLE
Reduce verbosity of noaction mode

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -174,6 +174,8 @@ sub close
         if ($diff) {
             *$self->{LOG}->verbose ("Changes to ", *$self->{filename}, ":");
             *$self->{LOG}->report ($diff);
+        } else {
+            *$self->{LOG}->debug(1, "No changes to make to ", *$self->{filename});
         }
     }
 

--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -171,9 +171,10 @@ sub close
                                   stdin => "$self", stdout => \$diff,
                                   keeps_state => 1);
         $cmd->execute();
-        *$self->{LOG}->verbose ("Changes to ", *$self->{filename}, ":");
-        $diff = "" if (! defined($diff));
-        *$self->{LOG}->report ($diff);
+        if ($diff) {
+            *$self->{LOG}->verbose ("Changes to ", *$self->{filename}, ":");
+            *$self->{LOG}->report ($diff);
+        }
     }
 
     if (*$self->{save}) {


### PR DESCRIPTION
Do not try to print the changes if the diff is empty. This makes the
output less noisy if a large number of files are opened, but only some
of them are changed.

Originally pushed to SF by @gombasg, but seems to have got lost on the way to GitHub.