### PR TITLE
fix race condition in locking

### DIFF
--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -72,8 +72,8 @@ The B<CAF::Lock> class provides methods for handling application locking.
 =item set_lock(I<retries>, I<timeout>, I<force>)
 
 Tries I<retries> times to set the lock.  If I<force> is set to B<FORCE_NONE>
-or not defined and the lock is set, it sleeps for
-rand(I<timeout>).  Returns B<SUCCESS>, or B<undef> on failure.
+or not defined and the lock is set, it sleeps for I<timeout>.  Returns
+B<SUCCESS>, or B<undef> on failure.
 
 If I<retries> or I<timeout> are not defined or set to 0, only a single
 attempt is done to acquire the lock.
@@ -101,7 +101,7 @@ sub set_lock {
   do {
     if ($tries > 0) {
       $self->verbose("lock file is already held, try $tries out of $retries");
-      sleep(rand($timeout));
+      sleep($timeout);
     }
     $tries++;
     return SUCCESS if $self->_try_lock($force);

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -93,7 +93,7 @@ sub set_lock {
 
   if ($self->{LOCK_SET}) {
     # oops.
-    $self->error("lock already set by this application instance");
+    $self->error("lock already set by this application instance: $self->{LOCK_FILE}");
     return;
   }
 
@@ -107,7 +107,7 @@ sub set_lock {
     return SUCCESS if $self->_try_lock($force);
   } while ($tries < $retries && $timeout);
 
-  $self->error("cannot acquire lock: " . $self->{LOCK_FILE});
+  $self->error("cannot acquire lock: $self->{LOCK_FILE}");
   return;
 }
 
@@ -128,16 +128,16 @@ sub unlock {
     # if we forced the lock LOCK_FH can be undef
     if ($self->{LOCK_FH}) {
       unless (flock($self->{LOCK_FH}, LOCK_UN)) {
-        $self->error("cannot release lock: ",$self->{LOCK_FILE});
+        $self->error("cannot release lock: $self->{LOCK_FILE}");
         return;
       }
-      $self->error("cannot close lock file: ",$self->{LOCK_FILE})
+      $self->error("cannot close lock file: $self->{LOCK_FILE}")
           unless $self->{LOCK_FH}->close();
     }
     $self->{LOCK_SET} = undef;
     $self->{LOCK_FH} = undef;
   } else {
-    $self->error("lock not held by this application instance, not unlocking");
+    $self->error("lock not held by this application instance: $self->{LOCK_FILE}, not unlocking");
     return;
   }
   return SUCCESS;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -184,14 +184,12 @@ is returned.
 sub unlock {
   my $self=shift;
   if ($self->{LOCK_SET}) {
-    flock ($self->{LOCK_FH}, LOCK_UN|LOCK_NB) or $self->error("cannot release flock on lock file: ",$self->{'LOCK_FILE'});
-    $self->{LOCK_FH}->close or $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
-    unless (unlink($self->{'LOCK_FILE'})) {
-      $self->error("cannot release lock file: ",$self->{'LOCK_FILE'});
-      return undef;
-    } else {
-      $self->{LOCK_SET}=undef;
+    # if we forced the lock LOCK_FH can be undef
+    return SUCCESS unless ($self->{LOCK_FH});
+    unless ($self->{LOCK_FH}->close) {
+      $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
     }
+    $self->{LOCK_SET}=undef;
   } else {
     $self->error("lock not held by this application instance, not unlocking");
     return undef;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -48,8 +48,6 @@ CAF::Lock - Class for handling application instance locking
   unless ($lock->set_lock(10,2) {...}
   unless ($lock->set_lock(3,3,FORCE_IF_STALE)) {...}
 
-  if ($lock->is_stale()) {...} else {...};
-
   unless ($lock->unlock()) {....}
 
 
@@ -128,29 +126,6 @@ sub get_lock_pid {
   return $1;
 }
 
-
-=pod
-
-=item is_stale()
-
-Returns SUCCESS if the lock is stale - a lock file is set but the
-corresponding PID does not exist. Returns undef otherwise.
-
-=cut
-
-sub is_stale {
-  my $self=shift;
-
-  return undef unless ($self->is_locked());
-  my $lock_pid=$self->get_lock_pid();
-  if ($lock_pid && kill(0, $lock_pid)) {
-      return undef;
-  } else {
-      return SUCCESS;
-  }
-}
-
-
 =pod
 
 =item set_lock ($retries,$timeout,$force);
@@ -167,12 +142,8 @@ If $force is set to FORCE_ALWAYS then the lockfile is just set
 again, independently if the lock is already set by another application
 instance.
 
-If $force is set to FORCE_IF_STALE then the lockfile is set if the
-application instance holding the lock is dead (PID not alive).
-
-If $force is set to FORCE_ALWAYS, or if $force is defined to
-FORCE_IF_STALE and a stale lock file is detected, then neither
-$timeout nor $retries are taken into account.
+If $force is set to FORCE_ALWAYS then neither $timeout nor $retries are taken
+into account.
 
 =cut
 

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -75,9 +75,8 @@ sub set_lock
     $timeout = 0 unless (defined $retries);
 
     if ($self->{LOCK_SET}) {
-        # oops.
-        $self->error("lock already set by this application instance: $self->{LOCK_FILE}");
-        return;
+        $self->warn("lock already set by this application instance: $self->{LOCK_FILE}");
+        return SUCCESS;
     }
 
     my $tries = 0;
@@ -119,8 +118,7 @@ sub unlock
         $self->{LOCK_SET} = undef;
         $self->{LOCK_FH} = undef;
     } else {
-        $self->error("lock not held by this application instance: $self->{LOCK_FILE}, not unlocking");
-        return;
+        $self->warn("lock not held by this application instance: $self->{LOCK_FILE}, nothing to unlock");
     }
     return SUCCESS;
 }

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -234,6 +234,8 @@ is returned.
 sub unlock {
   my $self=shift;
   if ($self->{LOCK_SET}) {
+    flock ($self->{LOCK_FH}, LOCK_UN|LOCK_NB) or $self->error("cannot release flock on lock file: ",$self->{'LOCK_FILE'});
+    $self->{LOCK_FH}->close or $self->error("cannot close lock file: ",$self->{'LOCK_FILE'});
     unless (unlink($self->{'LOCK_FILE'})) {
       $self->error("cannot release lock file: ",$self->{'LOCK_FILE'});
       return undef;

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -11,6 +11,7 @@ use CAF::Reporter;
 
 use LC::Exception qw (SUCCESS throw_error);
 use FileHandle;
+use Fcntl qw(:flock);
 #use Proc::ProcessTable;
 
 use Exporter;
@@ -85,7 +86,10 @@ If a lock is set for the lock file, returns SUCCESS, undef otherwise.
 
 sub is_locked {
   my $self=shift;
-  return SUCCESS if (-e $self->{'LOCK_FILE'});
+  if (-e $self->{'LOCK_FILE'}) {
+    my $fh=FileHandle->new("> ". $self->{'LOCK_FILE'});
+    return SUCCESS unless (flock($fh, LOCK_EX|LOCK_NB));
+  }
   return undef;
 }
 

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -158,23 +158,6 @@ sub is_set {
   return;
 }
 
-##############################################################################
-#
-# The following methods are provided for backwards compatibility only
-# and have been deprecated
-#
-sub get_lock_pid {
-  return;
-}
-
-sub is_stale {
-  return;
-}
-
-*is_locked = \&is_set;
-##############################################################################
-
-
 =pod
 
 =back

--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -278,26 +278,6 @@ sub _initialize {
 }
 
 
-
-=pod
-
-=item DESTROY
-
-called during garbage collection. Invokes unlock() if lock is set by
-application instance.
-
-=cut
-
-
-sub DESTROY {
-  my $self = shift;
-  # We unlock only on the process that owns the lock.  Otherwise this
-  # might be a forked process that is exiting and shouldn't sweep
-  # under its parent's feet.
-  $self->unlock() if $self->{LOCK_SET} && $self->get_lock_pid() == $$;
-}
-
-
 =pod
 
 =back

--- a/src/test/perl/lock.t
+++ b/src/test/perl/lock.t
@@ -13,15 +13,29 @@ unlink(LOCK_TEST);
 my $lock1 = CAF::Lock->new(LOCK_TEST);
 my $lock2 = CAF::Lock->new(LOCK_TEST);
 
-ok(!$lock1->is_set(), "Unlocked at start");
-ok($lock1->set_lock(), "Lock set");
-ok($lock1->is_set(), "Locked on request");
+ok(!$lock1->is_set(), "lock1 unlocked at start");
+ok(!$lock2->is_set(), "lock2 unlocked at start");
 
-ok(!$lock2->set_lock(), "Second lock when file locked");
+# TODO is this ok?
+ok(! $lock2->unlock(), "lock2 lock released (while lock2 unlocked)");
+ok(!$lock2->is_set(), "lock2 still unlocked after unlock while unlocked");
 
-ok($lock1->unlock(), "Lock released");
 
-ok($lock2->set_lock(), "Second lock when file unlocked");
-ok($lock2->is_set(), "Second lock locked on request");
+ok($lock1->set_lock(), "lock1 lock set");
+ok($lock1->is_set(), "lock1 locked on request");
+ok(!$lock2->is_set(), "lock2 unlocked when lock1 locked");
+
+ok(! $lock1->set_lock(), "lock1 set on when lock1 already taken");
+
+ok(!$lock2->set_lock(), "lock2 not set when lock1 locked");
+ok(!$lock2->is_set(), "lock2 failed set still unlocked when lock1 locked");
+
+ok($lock1->unlock(), "lock1 lock released");
+ok(!$lock1->is_set(), "lock1 unlocked when lock1 unlocked");
+ok(!$lock2->is_set(), "lock2 unlocked when lock1 unlocked");
+
+ok($lock2->set_lock(), "lock2 set when lock1 unlocked");
+ok($lock2->is_set(), "lock2 locked on request");
+ok(!$lock1->is_set(), "lock1 unlocked when lock2 unlocked");
 
 done_testing();

--- a/src/test/perl/lock.t
+++ b/src/test/perl/lock.t
@@ -13,38 +13,10 @@ unlink(LOCK_TEST);
 my $lock=CAF::Lock->new(LOCK_TEST);
 
 ok(!$lock->is_locked(), "Unlocked at start");
-my $lockpid=$lock->get_lock_pid();
-
-is($lockpid, undef, "Lock PID undefined on unaquired lock");
 
 ok($lock->set_lock(), "Lock set");
 ok($lock->is_locked(), "Locked on request");
 
-is($lock->get_lock_pid(), $$, "Lock PID correctly set on locked object");
-
-ok(!$lock->is_stale(), "Lock is NOT stale");
-
 ok($lock->unlock(), "Lock released");
-
-open(my $fh, ">", LOCK_TEST);
-if (!kill(0, $$+1)) {
-    print $fh $$+1;
-    close($fh);
-    ok($lock->is_stale(), "Lock by non-existing process is stale");
-}
-
-ok(!$lock->set_lock(), "Non-forced lock on stalled lock not acuired");
-ok($lock->set_lock(0, 0, FORCE_IF_STALE), "Forced lock on stalled resource aquired");
-$lock->unlock();
-
-open($fh, ">", LOCK_TEST);
-close($fh);
-
-ok($lock->is_stale(), "Lock on empty lock file is stale");
-ok($lock->set_lock(0, 0, FORCE_IF_STALE), "Forced lock on empty lock file aquired");
-
-# How does it handle when an empty lock file is there?
-
-
 
 done_testing();

--- a/src/test/perl/lock.t
+++ b/src/test/perl/lock.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More;
-use CAF::Lock qw(FORCE_IF_STALE FORCE_ALWAYS);
+use CAF::Lock qw(FORCE_ALWAYS);
 
 use constant LOCK_TEST_DIR => "target/tests";
 use constant LOCK_TEST => LOCK_TEST_DIR . "/lock-caf";
@@ -10,13 +10,18 @@ use constant LOCK_TEST => LOCK_TEST_DIR . "/lock-caf";
 mkdir(LOCK_TEST_DIR);
 unlink(LOCK_TEST);
 
-my $lock=CAF::Lock->new(LOCK_TEST);
+my $lock1 = CAF::Lock->new(LOCK_TEST);
+my $lock2 = CAF::Lock->new(LOCK_TEST);
 
-ok(!$lock->is_locked(), "Unlocked at start");
+ok(!$lock1->is_set(), "Unlocked at start");
+ok($lock1->set_lock(), "Lock set");
+ok($lock1->is_set(), "Locked on request");
 
-ok($lock->set_lock(), "Lock set");
-ok($lock->is_locked(), "Locked on request");
+ok(!$lock2->set_lock(), "Second lock when file locked");
 
-ok($lock->unlock(), "Lock released");
+ok($lock1->unlock(), "Lock released");
+
+ok($lock2->set_lock(), "Second lock when file unlocked");
+ok($lock2->is_set(), "Second lock locked on request");
 
 done_testing();

--- a/src/test/perl/lock.t
+++ b/src/test/perl/lock.t
@@ -16,16 +16,14 @@ my $lock2 = CAF::Lock->new(LOCK_TEST);
 ok(!$lock1->is_set(), "lock1 unlocked at start");
 ok(!$lock2->is_set(), "lock2 unlocked at start");
 
-# TODO is this ok?
-ok(! $lock2->unlock(), "lock2 lock released (while lock2 unlocked)");
+ok($lock2->unlock(), "lock2 lock released (while lock2 unlocked)");
 ok(!$lock2->is_set(), "lock2 still unlocked after unlock while unlocked");
-
 
 ok($lock1->set_lock(), "lock1 lock set");
 ok($lock1->is_set(), "lock1 locked on request");
 ok(!$lock2->is_set(), "lock2 unlocked when lock1 locked");
 
-ok(! $lock1->set_lock(), "lock1 set on when lock1 already taken");
+ok($lock1->set_lock(), "lock1 set on when lock1 already taken");
 
 ok(!$lock2->set_lock(), "lock2 not set when lock1 locked");
 ok(!$lock2->is_set(), "lock2 failed set still unlocked when lock1 locked");
@@ -33,6 +31,8 @@ ok(!$lock2->is_set(), "lock2 failed set still unlocked when lock1 locked");
 ok($lock1->unlock(), "lock1 lock released");
 ok(!$lock1->is_set(), "lock1 unlocked when lock1 unlocked");
 ok(!$lock2->is_set(), "lock2 unlocked when lock1 unlocked");
+
+ok($lock1->unlock(), "lock1 lock released while lock1 already released");
 
 ok($lock2->set_lock(), "lock2 set when lock1 unlocked");
 ok($lock2->is_set(), "lock2 locked on request");


### PR DESCRIPTION
By introducing flock() a race condition can be avoided. This avoids if 2
ncm-ncd processes are started exactly the same time and both believe he
has the lock.