### PR TITLE
Kerberos: make it work

### DIFF
--- a/src/main/perl/Kerberos.pm
+++ b/src/main/perl/Kerberos.pm
@@ -1,12 +1,4 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-
-package CAF::Kerberos;
-
-use strict;
-use warnings;
+${PMpre} CAF::Kerberos${PMpost}
 
 use parent qw(CAF::Object);
 use Readonly;

--- a/src/main/perl/Kerberos.pm
+++ b/src/main/perl/Kerberos.pm
@@ -266,7 +266,7 @@ sub create_credential_cache
         return $self->fail("Failed to set permissons on credential cache dir $tmppath");
     } else {
         $self->{ccdir} = $tmppath;
-        $self->{ENV}->{$KRB5ENV_CCNAME} = "DIR:$tmppath";
+        $self->{ENV}->{$KRB5ENV_CCNAME} = "FILE:$tmppath/tkt";
     }
 
     $self->verbose("credential cache: ". $self->{ccdir});

--- a/src/main/perl/Kerberos.pm
+++ b/src/main/perl/Kerberos.pm
@@ -314,6 +314,10 @@ sub get_context
         return if(! defined($name));
     }
 
+    if(! defined($self->{ccdir})) {
+        return if ! defined($self->create_credential_cache());
+    }
+
     my $iflags = defined($opts{iflags}) ? $opts{iflags} : 0;
     # Do not log itoken for security reasons
     # Do not use GSS_C_NO_BUFFER as default, it gives

--- a/src/test/perl/kerberos.t
+++ b/src/test/perl/kerberos.t
@@ -157,7 +157,8 @@ is_deeply($krb->{principal}, {
 $tmppath = "target/cc_dir";
 ok($krb->create_credential_cache(), 'create_credential_cache returns success');
 is($krb->{ccdir}, $tmppath, 'expected credential cache directory');
-is($krb->{ENV}->{KRB5CCNAME}, "DIR:$tmppath", 'define credential cache directory KRB5CCNAME');
+is($krb->{ENV}->{KRB5CCNAME}, "FILE:$tmppath/tkt",
+   'define credential cache FILE as tkt in directory KRB5CCNAME');
 
 
 # _process is tested in kerberos-process

--- a/src/test/perl/kerberos.t
+++ b/src/test/perl/kerberos.t
@@ -99,6 +99,12 @@ ok(! defined($krb->_split_principal_string('/b@c')),
 # Test generation, incl failure
 ok(! defined($krb->_principal_string({'noprimary' => 'woohoo'})),
    '_principal_string returns undef if no primary is set');
+ok(! defined($krb->_principal_string({'primary' => '()woohoo'})),
+   '_principal_string returns undef if primary has invalid characters');
+ok(! defined($krb->_principal_string({'primary' => 'woohoo', instances => ["valid", "invalid()"]})),
+   '_principal_string returns undef if one of the instances has invalid characters');
+ok(! defined($krb->_principal_string({'primary' => 'woohoo', realm => 'realm()'})),
+   '_principal_string returns undef if realm has invalid characters');
 is($krb->_principal_string({'primary' => 'p', 'instances' => [qw(i0 i1)], 'realm' => 'realm'}),
    'p/i0/i1@realm', 'Correct principal string generated from provided hashref');
 is($krb->_principal_string(),
@@ -116,6 +122,10 @@ ok(! defined($krb->update_principal(principal => 'a@b@c')),
 ok(! defined($krb->update_principal(instances => 'myinstances')),
    'update_principal failed with invalid instances (must be arrayref)');
 is_deeply($krb->{principal}, $init_principal, 'principal unmodified with update_principal error');
+
+# This does modify the current attributes, all valid ones are changed
+ok(! defined($krb->update_principal(principal => 'a/()b@c')),
+   'update_principal failed with principal with valid structure but with invalid characters');
 
 # Test update
 $krb->update_principal(primary => 'newprim', instances => [qw(i0 i1)], realm => 'r1');

--- a/src/test/perl/kerberos.t
+++ b/src/test/perl/kerberos.t
@@ -248,6 +248,8 @@ foreach my $class (sort keys %$gssapi_wrappers) {
         # reset fail attribute
         $krb->{fail} = '';
         my $fname = "_gssapi_$method";
+        my $fclass = join('::', 'GSSAPI', $class);
+        my $fmethod = join('::', $fclass, $method);
 
         # Test that there are no doubles (e.g. same method name in Context and Name)
         is(scalar (grep {$_ eq $fname} @fnames), 0, "$fname is unique method name");
@@ -265,14 +267,14 @@ foreach my $class (sort keys %$gssapi_wrappers) {
             # eval{} does not catch this. Is this some bug in the XS?
             $krb->{fail} = '';
             ok(! defined($krb->$fname($a, $b, $c)), "$fname returns undef in of croak");
-            my $err_regexp = "^$fname GSSAPI::$class::$method croaked:";
+            my $err_regexp = "^$fname $fmethod croaked:";
             like($krb->{fail}, qr{$err_regexp}, "$fname fails with croaked message when incorrect args are passed");
         }
 
         $krb->{fail} = '';
         $a = {};
         ok(! defined($krb->$fname($a, $b, $c)), "$fname returns undef in case of instance mismatch");
-        my $err_regexp = "^$fname expected a GSSAPI::$class instance, got ref";
+        my $err_regexp = "^$fname expected a $fclass instance, got ref";
         like($krb->{fail}, qr{$err_regexp}, "$fname fails with instance mismatch");
     }
 }


### PR DESCRIPTION
The previous CAF::Kerberos had the correct code path, but was not working because interacting with XS requires careful passing around of the variables.