### PR TITLE
FileEditor: fix tempfile() calling sequence in unit tests

### DIFF
--- a/src/test/perl/test-caffileeditor.t
+++ b/src/test/perl/test-caffileeditor.t
@@ -12,7 +12,7 @@ use File::Temp qw(tempfile);
 
 my $testdir = 'target/test/editor';
 mkpath($testdir);
-our $filename = tempfile(DIR => $testdir);
+(undef, our $filename) = tempfile(DIR => $testdir);
 
 use constant TEXT => <<EOF;
 En un lugar de La Mancha, de cuyo nombre no quiero acordarme

--- a/src/test/perl/test-caffileeditor_add_or_replace.t
+++ b/src/test/perl/test-caffileeditor_add_or_replace.t
@@ -15,7 +15,7 @@ use File::Temp qw(tempfile);
 
 my $testdir = 'target/test/editor';
 mkpath($testdir);
-our $filename = tempfile(DIR => $testdir);
+(undef, our $filename) = tempfile(DIR => $testdir);
 chomp($filename);
 
 my ($log, $str);

--- a/src/test/perl/test-caffileeditor_positions.t
+++ b/src/test/perl/test-caffileeditor_positions.t
@@ -14,7 +14,7 @@ use File::Temp qw(tempfile);
 
 my $testdir = 'target/test/editor';
 mkpath($testdir);
-our $filename = tempfile(DIR => $testdir);
+(undef, our $filename) = tempfile(DIR => $testdir);
 
 chomp($filename);
 


### PR DESCRIPTION
Fixes #150.

See http://perldoc.perl.org/File/Temp.html for details.