### PR TITLE
FileEditor: add a 'source' option in constructor

### DIFF
--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -58,13 +58,38 @@ sub _is_valid_source
     return -f $fn;
 }
 
+sub _is_reference_newer
+{
+    my ($self) = @_;
+    my $is_newer = 0;   # Assume false
+    if ( $self->_is_valid_source(*$self->{options}->{source}) ) {
+        if ( !$self->_is_valid_source(*$self->{filename}) || 
+             ((stat(*$self->{options}->{source}))[9] > (stat(*$self->{filename}))[9]) ) {
+          $is_newer = 1
+        }
+    }
+    if ( $is_newer ) {
+        *$self->{LOG}->debug(2, "Source file (", *$self->{options}->{source}, " is newer than ", *$self->{filename}, ": use it");
+    } else {
+        *$self->{LOG}->debug(2, "Source file (", *$self->{options}->{source}, " older than ", *$self->{filename}, ": ignore it");
+    };
+    return $is_newer;
+}
 
 sub new
 {
     my $class = shift;
     my $self = $class->SUPER::new (@_);
-    if ($self->_is_valid_source(*$self->{filename})) {
-        my $txt = LC::File::file_contents (*$self->{filename});
+    my $txt;
+    my ($path, %opts) = @_;
+
+    *$self->{options}->{source} = $opts{source} if exists ($opts{source});
+    if ( exists(*$self->{options}->{source}) && $self->_is_reference_newer() ) {
+        $txt = LC::File::file_contents (*$self->{options}->{source});
+    } elsif ($self->_is_valid_source(*$self->{filename})) {
+        $txt = LC::File::file_contents (*$self->{filename});
+    }
+    if ( $txt ) {
         $self->IO::String::open ($txt);
         $self->seek(IO_SEEK_END);
     }

--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -63,7 +63,7 @@ the file contents based on a new version of the reference file.
 =cut
 
 # FileEditor supports reading/editing a file
-sub _is_valid_source
+sub _is_valid_file
 {
     my ($self, $fn) = @_;
     return -f $fn;
@@ -78,9 +78,9 @@ sub _is_reference_newer
 {
     my ($self) = @_;
     my $is_newer = 0;   # Assume false
-    if (  exists(*$self->{options}->{source}) && $self->_is_valid_source(*$self->{options}->{source}) ) {
+    if (  exists(*$self->{options}->{source}) && $self->_is_valid_file(*$self->{options}->{source}) ) {
         # stat()[9] is modification time
-        if ( !$self->_is_valid_source(*$self->{filename}) || 
+        if ( !$self->_is_valid_file(*$self->{filename}) || 
              ((stat(*$self->{options}->{source}))[9] > (stat(*$self->{filename}))[9]) ) {
           $is_newer = 1
         }
@@ -107,7 +107,7 @@ sub new
     *$self->{options}->{source} = $opts{source} if exists ($opts{source});
     if ( $self->_is_reference_newer() ) {
         $src_file = *$self->{options}->{source};
-    } elsif ($self->_is_valid_source(*$self->{filename})) {
+    } elsif ($self->_is_valid_file(*$self->{filename})) {
         $src_file = *$self->{filename};
     }
     if ( $src_file ) {

--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -71,6 +71,7 @@ sub _is_reference_newer
     my ($self) = @_;
     my $is_newer = 0;   # Assume false
     if (  exists(*$self->{options}->{source}) && $self->_is_valid_source(*$self->{options}->{source}) ) {
+        # stat()[9] is modification time
         if ( !$self->_is_valid_source(*$self->{filename}) || 
              ((stat(*$self->{options}->{source}))[9] > (stat(*$self->{filename}))[9]) ) {
           $is_newer = 1
@@ -102,7 +103,7 @@ sub new
         $src_file = *$self->{filename};
     }
     if ( $src_file ) {
-        *$self->{LOG}->debug(2, "Reading initial contents from $src_file");
+        *$self->{LOG}->debug(2, "Reading initial contents from $src_file") if *$self->{LOG};
         my $txt = LC::File::file_contents ($src_file);
         $self->IO::String::open ($txt);
         $self->seek(IO_SEEK_END);

--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -47,15 +47,18 @@ the class constructor.
 =item new
 
 Returns a new object it accepts the same arguments as the constructor
-for C<CAF::FileWriter> with one additional option: C<source>. This
-option, when present, must be a file name whose contents will be used
+for C<CAF::FileWriter> with one additional option: 
+
+=over
+
+=item source 
+
+This option, when present, must be a file name whose contents will be used
 as the initial contents for the edited file if the source modification time
 is more recent than the edited file modification time. This allows to rebuild
-the file contents based on a new version of the reference/template file. 
+the file contents based on a new version of the reference file. 
 
-An example is:
-
-    my $fh = CAF::FileEditor('/my/file', source => '/ref/file');
+=back
 
 =cut
 
@@ -66,6 +69,11 @@ sub _is_valid_source
     return -f $fn;
 }
 
+# This method is only intended to be used in the context of the constructor
+# and entirely relies on the internal structure of the FileEditor object.
+# 'filename`  is the file name passed with instantiating the FileEditor and
+# 'options/sources' the 'source' parameter value (called a reference file
+# internally).
 sub _is_reference_newer
 {
     my ($self) = @_;

--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -78,11 +78,17 @@ sub _is_reference_newer
 {
     my ($self) = @_;
     my $is_newer = 0;   # Assume false
-    if (  exists(*$self->{options}->{source}) && $self->_is_valid_file(*$self->{options}->{source}) ) {
-        # stat()[9] is modification time
-        if ( !$self->_is_valid_file(*$self->{filename}) || 
-             ((stat(*$self->{options}->{source}))[9] > (stat(*$self->{filename}))[9]) ) {
+    if (  exists(*$self->{options}->{source}) ) {
+        # It is valid for the source value to be a pipe: in this case consider it
+        # as newer than an existing file.
+        if ( -p *$self->{options}->{source} ) {
           $is_newer = 1
+        } elsif ( $self->_is_valid_file(*$self->{options}->{source}) ) {
+        # stat()[9] is modification time
+            if ( !$self->_is_valid_file(*$self->{filename}) || 
+                 ((stat(*$self->{options}->{source}))[9] > (stat(*$self->{filename}))[9]) ) {
+               $is_newer = 1
+            }
         }
     }
     #FIXME: replace by $self->debug() after PR #154 has been merged...

--- a/src/main/perl/FileReader.pm
+++ b/src/main/perl/FileReader.pm
@@ -41,7 +41,7 @@ seek to the beginning and C<cancel> any (future) changes.
 =cut
 
 # FileReader supports reading a file or pipe
-sub _is_valid_source
+sub _is_valid_file
 {
     my ($self, $fn) = @_;
     return -f $fn || -p $fn;

--- a/src/test/perl/test-caffileeditor_source.t
+++ b/src/test/perl/test-caffileeditor_source.t
@@ -5,11 +5,29 @@ use FindBin qw($Bin);
 use lib "$Bin/modules";
 use CAF::FileEditor;
 use Test::More tests => 7;
+use Test::MockModule;
 use Test::Quattor::Object;
 use Carp qw(confess);
 use File::Path;
 use File::Temp qw(tempfile);
 use Readonly;
+
+$SIG{__DIE__} = \&confess;
+
+# FIXME:
+# LC::File::file_contents (used by CAF::FileEditor constructor) doesn't work 
+# in the unit test context. Mock it until we find a better solution...
+our $lcfile = Test::MockModule->new("LC::File");
+
+sub read_file_contents {
+    my $fname = shift;
+    my $fh;
+    open($fh, "<", $fname) || die ("failed to open $fname");
+    my $contents = join('', <$fh>);
+    return $contents;
+}
+$lcfile->mock("file_contents", \&read_file_contents);
+
 
 my $testdir = 'target/test/editor';
 mkpath($testdir);
@@ -23,8 +41,6 @@ Readonly my $ANOTHER_TEXT => "adarga antigua, rocín flaco y galgo corredor.";
 
 my $fh;
 my $obj = Test::Quattor::Object->new();
-
-$SIG{__DIE__} = \&confess;
 
 
 # Create a file and check that it is empty

--- a/src/test/perl/test-caffileeditor_source.t
+++ b/src/test/perl/test-caffileeditor_source.t
@@ -29,7 +29,7 @@ sub read_file_contents {
 $lcfile->mock("file_contents", \&read_file_contents);
 
 
-my $testdir = 'target/test/editor';
+my $testdir = 'target/test/test_caffileeditor_source';
 mkpath($testdir);
 (undef, my $filename) = tempfile(DIR => $testdir);
 
@@ -52,7 +52,8 @@ $fh->close();
 
 # Check that reference file contents is used as the initial contents when it
 # is newer than the file edited.
-sleep 2;
+my $time=time();
+utime(undef, $time - 10, $filename); # make filename old enough
 my ($ref_fh, $ref_filename) = tempfile(DIR => $testdir);
 print $ref_fh $TEXT;
 $ref_fh->close();
@@ -64,7 +65,8 @@ $fh->close();
 
 # Check that reference file contents is not used as the initial contents when it
 # is older than the file edited.
-sleep 2;
+$time=time();
+utime(undef, $time - 10, $ref_filename); # make ref_filename old enough
 my ($new_fh, $new_filename) = tempfile(DIR => $testdir);
 print $new_fh $ANOTHER_TEXT;
 $new_fh->close();

--- a/src/test/perl/test-caffileeditor_source.t
+++ b/src/test/perl/test-caffileeditor_source.t
@@ -4,20 +4,22 @@ use warnings;
 use FindBin qw($Bin);
 use lib "$Bin/modules";
 use CAF::FileEditor;
-use Test::More tests => 3;
+use Test::More tests => 7;
 use Test::Quattor::Object;
 use Carp qw(confess);
 use File::Path;
 use File::Temp qw(tempfile);
+use Readonly;
 
 my $testdir = 'target/test/editor';
 mkpath($testdir);
 (undef, my $filename) = tempfile(DIR => $testdir);
 
-use constant TEXT => <<EOF;
+Readonly my $TEXT => <<EOF;
 En un lugar de La Mancha, de cuyo nombre no quiero acordarme
 no ha tiempo que vivía un hidalgo de los de lanza en astillero...
 EOF
+Readonly my $ANOTHER_TEXT => "adarga antigua, rocín flaco y galgo corredor.";
 
 my $fh;
 my $obj = Test::Quattor::Object->new();
@@ -36,19 +38,24 @@ $fh->close();
 # is newer than the file edited.
 sleep 2;
 my ($ref_fh, $ref_filename) = tempfile(DIR => $testdir);
-print $ref_fh TEXT;
+print $ref_fh $TEXT;
 $ref_fh->close();
 $fh = CAF::FileEditor->new($filename, log => $obj, source => $ref_filename);
-is("$fh",TEXT,"Reference file ($filename) contents used");
+is(*$fh->{options}->{source},$ref_filename,"File source is correctly defined");
+ok($fh->_is_reference_newer(),"Source file ($ref_filename) is newer than actual file ($filename)");
+is("$fh",$TEXT,"Reference file ($filename) contents used");
 $fh->close();
 
 # Check that reference file contents is not used as the initial contents when it
 # is older than the file edited.
 sleep 2;
 my ($new_fh, $new_filename) = tempfile(DIR => $testdir);
+print $new_fh $ANOTHER_TEXT;
 $new_fh->close();
 $new_fh = CAF::FileEditor->new($new_filename, log => $obj, source => $ref_filename);
-is("$new_fh","","Existing file ($new_filename) contents used");
+is(*$new_fh->{options}->{source},$ref_filename,"File source is correctly defined");
+ok(!$new_fh->_is_reference_newer(),"Source file ($ref_filename) is older than actual file ($filename)");
+is("$new_fh",$ANOTHER_TEXT,"Existing file ($new_filename) contents used");
 $fh->close();
 
 done_testing();

--- a/src/test/perl/test-caffileeditor_source.t
+++ b/src/test/perl/test-caffileeditor_source.t
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/modules";
+use testapp;
+use CAF::FileEditor;
+use Test::More tests => 3;
+use Test::Quattor::Object;
+use Carp qw(confess);
+use File::Path;
+use File::Temp qw(tempfile);
+
+my $testdir = 'target/test/editor';
+mkpath($testdir);
+(undef, my $filename) = tempfile(DIR => $testdir);
+
+use constant TEXT => <<EOF;
+En un lugar de La Mancha, de cuyo nombre no quiero acordarme
+no ha tiempo que vivía un hidalgo de los de lanza en astillero...
+EOF
+use constant HEADTEXT => <<EOF;
+... adarga antigua, rocín flaco y galgo corredor.
+EOF
+
+my $fh;
+my $this_app = testapp->new ($0, qw (--verbose));
+my $obj = Test::Quattor::Object->new();
+
+$SIG{__DIE__} = \&confess;
+
+*testapp::error = sub {
+    my $self = shift;
+    $self->{ERROR} = @_;
+};
+
+# Create a file and check that it is empty
+($fh, $filename) = tempfile(DIR => $testdir);
+$fh->close();
+$fh = CAF::FileEditor->new($filename, log => $obj);
+$fh->cancel;
+is("$fh","","Existing file ($filename) empty");
+$fh->close();
+
+# Check that reference file contents is used as the initial contents when it
+# is newer than the file edited.
+sleep 5;
+my ($ref_fh, $ref_filename) = tempfile(DIR => $testdir);
+print $ref_fh TEXT;
+$ref_fh->close();
+$fh = CAF::FileEditor->new($filename, log => $obj, source => $ref_filename);
+$fh->cancel;
+is("$fh",TEXT,"Reference file ($filename) contents used");
+$fh->close();
+
+# Check that reference file contents is not used as the initial contents when it
+# is older than the file edited.
+sleep 5;
+my ($new_fh, $new_filename) = tempfile(DIR => $testdir);
+$new_fh->close();
+$new_fh = CAF::FileEditor->new($new_filename, log => $obj, source => $ref_filename);
+$new_fh->cancel;
+is("$new_fh","","Existing file ($new_filename) contents used");
+$fh->close();
+
+done_testing();

--- a/src/test/perl/test-caffileeditor_source.t
+++ b/src/test/perl/test-caffileeditor_source.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use FindBin qw($Bin);
 use lib "$Bin/modules";
-use testapp;
 use CAF::FileEditor;
 use Test::More tests => 3;
 use Test::Quattor::Object;
@@ -19,47 +18,36 @@ use constant TEXT => <<EOF;
 En un lugar de La Mancha, de cuyo nombre no quiero acordarme
 no ha tiempo que vivía un hidalgo de los de lanza en astillero...
 EOF
-use constant HEADTEXT => <<EOF;
-... adarga antigua, rocín flaco y galgo corredor.
-EOF
 
 my $fh;
-my $this_app = testapp->new ($0, qw (--verbose));
 my $obj = Test::Quattor::Object->new();
 
 $SIG{__DIE__} = \&confess;
 
-*testapp::error = sub {
-    my $self = shift;
-    $self->{ERROR} = @_;
-};
 
 # Create a file and check that it is empty
 ($fh, $filename) = tempfile(DIR => $testdir);
 $fh->close();
 $fh = CAF::FileEditor->new($filename, log => $obj);
-$fh->cancel;
 is("$fh","","Existing file ($filename) empty");
 $fh->close();
 
 # Check that reference file contents is used as the initial contents when it
 # is newer than the file edited.
-sleep 5;
+sleep 2;
 my ($ref_fh, $ref_filename) = tempfile(DIR => $testdir);
 print $ref_fh TEXT;
 $ref_fh->close();
 $fh = CAF::FileEditor->new($filename, log => $obj, source => $ref_filename);
-$fh->cancel;
 is("$fh",TEXT,"Reference file ($filename) contents used");
 $fh->close();
 
 # Check that reference file contents is not used as the initial contents when it
 # is older than the file edited.
-sleep 5;
+sleep 2;
 my ($new_fh, $new_filename) = tempfile(DIR => $testdir);
 $new_fh->close();
 $new_fh = CAF::FileEditor->new($new_filename, log => $obj, source => $ref_filename);
-$new_fh->cancel;
 is("$new_fh","","Existing file ($new_filename) contents used");
 $fh->close();
 


### PR DESCRIPTION
This PR adds to the FileEditor the capability to open a reference version of the file instead of the file itself, if the reference file happens to be newer than the file. The typical use case is a file provided by a RPM that you edit with Quattor. You may want that if a new version of the RPM installs a new file as `.rpm-new`, your next run of Quattor applies modifications to this new version (this is particularly useful with the RuleBasedEditor). 

The idea is that you do it by adding a 'source' option whose value is a file name. If the source doesn't exist, it is just ignored. In this case the file will be used if it exists (current behaviour).