### PR TITLE
Path: disable chatty LC::Check by default unless NoAction

### DIFF
--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -27,6 +27,8 @@ Readonly::Hash my %LC_CHECK_DISPATCH => {
     status => \&LC::Check::status,
 };
 
+Readonly::Array my @LC_CHECK_SILENT_FUNCTIONS => qw(directory status file link symlink hardlink absence);
+
 our $EC = LC::Exception::Context->new->will_store_all;
 
 =pod
@@ -242,6 +244,15 @@ sub LC_Check
 
     # Override noaction passed via opts
     $opts->{noaction} = $noaction;
+
+    # make sure LC::Check::$function is silent unless in noaction mode
+    # (or when explicitly set via silent option)
+    if (! defined($opts->{silent}) &&
+        grep {$_ eq $function} @LC_CHECK_SILENT_FUNCTIONS
+        ) {
+        $opts->{silent} = $noaction ? 0 : 1
+    };
+
 
     my $funcref = $LC_CHECK_DISPATCH{$function};
     if (defined($funcref)) {

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -233,7 +233,7 @@ is_deeply($noaction_args, [30], "keeps_state option passed to _get_noaction");
 is_deeply($func_catch_args, [
               \&LC::Check::directory, # coderef to from the dispatch table
               [qw(a b c)],
-              {optX => 'x', 'noaction' => 20} # keeps_state is removed; noaction overridden with value from _get_noaction
+              {optX => 'x', 'noaction' => 20, silent => 0} # keeps_state is removed; noaction overridden with value from _get_noaction; silent=0 with noaction
           ], "_func_args called with expected args");
 
 verify_exception("LC_Check mocked directory dispatch");


### PR DESCRIPTION
Similar to #98