### PR TITLE
Object: add conditional log method

### DIFF
--- a/src/main/perl/Object.pm
+++ b/src/main/perl/Object.pm
@@ -144,7 +144,7 @@ to use an absolute rather than a conditional logger).
 =cut
 
 no strict 'refs';
-foreach my $i (qw(error warn info verbose debug report OK event)) {
+foreach my $i (qw(error warn info verbose debug report log OK event)) {
     *{$i} = sub {
         my ($self, @args) = @_;
         if ($self->{log}) {

--- a/src/test/perl/object.t
+++ b/src/test/perl/object.t
@@ -86,7 +86,7 @@ is($obj_ok->noAction(), 5, "noAction method returns NoAction");
 
 =cut
 
-foreach my $i (qw(error warn info verbose debug report OK event)) {
+foreach my $i (qw(error warn info verbose debug report log OK event)) {
 
     my $called = 0;
     # return funny value for testing


### PR DESCRIPTION
Add `log` method to list of conditional log methods, so all log methods from `Reporter` now have a conditonal couterpart (needed for https://github.com/quattor/ncm-ncd/issues/70)