### PR TITLE
CAF: Various fixes which fail documentation build

### DIFF
--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -67,10 +67,6 @@ configuration file parsing, and general application methods.
 
 Applications can extend or overwrite the default methods.
 
-=over
-
-=back
-
 =head2 Public methods
 
 =over 4

--- a/src/main/perl/FileReader.pm
+++ b/src/main/perl/FileReader.pm
@@ -15,15 +15,15 @@ use base qw(CAF::FileEditor);
 
 CAF::FileReader - Class for only reading files in CAF applications.
 
+=head1 DESCRIPTION
+
 Normal use:
 
-    use CAF::FileReader;
-    my $fh = CAF::FileReader->open ("my/path");
-    while (my $line = <$fh>) {
-       # Do something
-    }
-
-=head1 DESCRIPTION
+  use CAF::FileReader;
+  my $fh = CAF::FileReader->open ("my/path");
+  while (my $line = <$fh>) {
+     # Do something
+  }
 
 This class should be used whenever a file is to be opened for reading,
 and no modifications are expected.

--- a/src/main/perl/Log.pm
+++ b/src/main/perl/Log.pm
@@ -152,7 +152,7 @@ Examples:
     CAF::Log->new('/foo/bar', 'w') : truncate logfile, no timestamp
 
 If the filename ends with C<.log>, the C<SYSLOG> attribute is set to
-basename of the file without suffix (relevant for L<CAF::Reporter::syslog>).
+basename of the file without suffix (relevant for B<CAF::Reporter::syslog>).
 
 =cut
 

--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -55,7 +55,7 @@ Simplify common file and directory related operations e.g.
 
 =back
 
-The class is based on L<LC::Check> with following major difference
+The class is based on B<LC::Check> with following major difference
 
 =over
 
@@ -432,7 +432,7 @@ Additional options
 =item temp
 
 A boolean if true will create a a temporary directory using
-L<File::Temp::tempdir>.
+B<File::Temp::tempdir>.
 
 The directory name is the template to use (any trailing
 C<X> characters will be replaced with random characters by C<tempdir>;

--- a/src/main/perl/Reporter.pm
+++ b/src/main/perl/Reporter.pm
@@ -188,7 +188,7 @@ sub setup_reporter
 
 If C<$loginstance> is defined, it will be used as log file. C<$loginstance> can be
 any type of class object reference, but the object must support a
-C<print(@array)> method. Typically, it should be an C<CAF::Log>
+C<< print(@array) >> method. Typically, it should be an C<CAF::Log>
 instance. If C<$loginstance> is undefined, no log file will be used.
 
 Returns SUCCESS on success, undef otherwise.
@@ -211,7 +211,7 @@ sub set_report_logfile
 
 =item C<init_logfile($filename, $options)>: bool
 
-Create a new L<CAF::Log> instance with C<$filename> and C<$options> and
+Create a new B<CAF::Log> instance with C<$filename> and C<$options> and
 set it using C<set_report_logfile>.
 Returns SUCCESS on success, undef otherwise.
 
@@ -523,7 +523,7 @@ sub set_report_history
 
 =item init_history
 
-Create a L<CAF::History> instance to track events.
+Create a B<CAF::History> instance to track events.
 Argument C<keepinstances> is passed to the C<CAF::History>
 initialization.
 

--- a/src/main/perl/ReporterMany.pm
+++ b/src/main/perl/ReporterMany.pm
@@ -14,7 +14,7 @@ which allows more than one object instance each with its own reporting setup.
 =head1 DESCRIPTION
 
 C<CAF::ReporterMany> provides class methods for message reporting
-just like L<CAF::Reporter> does, with the main distinction that
+just like C<CAF::Reporter> does, with the main distinction that
 multiple instances do not share the reporter setup
 (e.g. they can each have their own debuglevel).
 

--- a/src/main/perl/RuleBasedEditor.pm
+++ b/src/main/perl/RuleBasedEditor.pm
@@ -15,9 +15,9 @@ the rule-based editor is called from a configuration module. Conditions can be d
 based on the contents of this configuration. Lines in the configuration file
 that don't match any rule are kept unmodified.
 
-This module is a subclass of the L<CAF::FileEditor>: it extends the base methods of
-the L<CAF::FileEditor>. It has only one public method (it uses the L<CAF::FileEditor> constructor).
-The methods provided in this module can be combined with L<CAF::FileEditor>
+This module is a subclass of the B<CAF::FileEditor>: it extends the base methods of
+the B<CAF::FileEditor>. It has only one public method (it uses the B<CAF::FileEditor> constructor).
+The methods provided in this module can be combined with B<CAF::FileEditor>
 methods to edit a file.
 
 Rules used to edit the file are defined in a hash: each entry (key/value pair) defines a rule.
@@ -98,7 +98,7 @@ An example of rule declaration is:
         "DISKFLAGS" =>"DiskFlags:dpm;".LINE_FORMAT_SH_VAR.";".LINE_VALUE_ARRAY,
        );
 
-For more comprehensive examples of rules, look at L<ncm-dpmlfc> or L<ncm-xrootd> source code in
+For more comprehensive examples of rules, look at B<ncm-dpmlfc> or B<ncm-xrootd> source code in
 configuration-modules-grid repository.
 
 =cut
@@ -163,13 +163,13 @@ Same remarks as for LINE_FORMAT_KW_VAL.
 =item *
 
 LINE_FORMAT_ENV_VAR:        export keyword=value (e.g. SH shell family). A comment is added at the
-end of the line if it is modified by L<CAF::RuleBasedEditor>. If the value contains whitespaces, it
+end of the line if it is modified by B<CAF::RuleBasedEditor>. If the value contains whitespaces, it
 is quoted.
 
 =item *
 
 LINE_FORMAT_SH_VAR:         keyword=value (e.g. SH shell family). A comment is added at the
-end of the line if it is modified by L<CAF::RuleBasedEditor>. If the value contains whitespaces, it
+end of the line if it is modified by B<CAF::RuleBasedEditor>. If the value contains whitespaces, it
 is quoted.
 
 =back
@@ -188,9 +188,7 @@ use enum qw(
 
 =pod
 
-=head3
-
-LINE_VALUE_xxx: how to interpret the configuration value
+=head3 LINE_VALUE_xxx: how to interpret the configuration value
 
 =over
 
@@ -219,7 +217,7 @@ C<LINE_VALUE_ARRAY> (the key list is treated as an array).
 
 =item
 
-LINE_VALUE_INSTANCE_PARAMS: specific to L<ncm-xrootd>
+LINE_VALUE_INSTANCE_PARAMS: specific to B<ncm-xrootd>
 
 =back
 

--- a/src/main/perl/TextRender.pm
+++ b/src/main/perl/TextRender.pm
@@ -153,7 +153,7 @@ Java properties format (using C<Config::Properties>),
 
 (Previously available module <general> was removed in 15.12.
 Component writers needing this functionality can use
-the L<CCM::TextRender> subclass instead).
+the B<CCM::TextRender> subclass instead).
 
 Or, for any other value, C<Template::Toolkit> is used, and the C<module> then indicates
 the relative path of the template to use.
@@ -170,7 +170,7 @@ It takes some extra optional arguments:
 
 =item C<log>, C<eol> and C<usecache>
 
-Handled by C<_initialize_textopts> from L<CAF::ObjectText>
+Handled by C<_initialize_textopts> from B<CAF::ObjectText>
 
 =item C<includepath>
 


### PR DESCRIPTION
This is not a full documentation cleanup but it provides various fixes throughout CAF for issues that break the documentation build, preventing automation. Mostly broken usage of links.

