### PR TITLE
Lock: make sure the CAF::Reporter is usable when no log instance is passed

### DIFF
--- a/src/main/perl/Lock.pm
+++ b/src/main/perl/Lock.pm
@@ -8,7 +8,10 @@ use Fcntl qw(:flock);
 use vars qw(@ISA @EXPORT @EXPORT_OK);
 
 # Only required to support legacy CAF::Reporter inheritance
+# Make sure nothing gets imported
+use CAF::Reporter qw();
 our @ISA;
+
 use parent qw(CAF::Object Exporter);
 
 our @EXPORT_OK = qw(FORCE_NONE FORCE_ALWAYS FORCE_IF_STALE);


### PR DESCRIPTION
Example code in https://github.com/quattor/CAF/issues/144 fails with
```
Can't locate package CAF::Reporter for @CAF::Lock::ISA at /usr/lib/perl/CAF/Lock.pm line 287.
```
This is only an issue when no log/reporter instance is passed during init.