### PR TITLE
Download/LWP and Kerberos: disable unitialized warnings while making local ENV copy

### DIFF
--- a/src/main/perl/Download/LWP.pm
+++ b/src/main/perl/Download/LWP.pm
@@ -49,9 +49,9 @@ my $_default_https_class;
 # first module to import it wins.
 
 # assigning undef to ENV gives warning in EL5
-my $_orig_val = $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS};
-local $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS};
-$ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = $_orig_val if defined($_orig_val);
+no warnings qw(uninitialized);
+local $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = $ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS};
+use warnings qw(uninitialized);
 
 BEGIN {
     Readonly $HTTPS_CLASS_NET_SSL => 'Net::SSL';
@@ -238,7 +238,12 @@ sub _get_ua
 
     # unclear if the enviroment is needed diuring init and/or during usage
     # set it in both cases, to be on the safe side
+
+    # assigning undef to ENV gives warning in EL5
+    no warnings qw(uninitialized);
     local %ENV = %ENV;
+    use warnings qw(uninitialized);
+
     $self->update_env(\%ENV);
     my $lwp = LWP::UserAgent->new(%lwp_opts);
     $lwp->timeout($opts{timeout}) if (defined($opts{timeout}));
@@ -261,7 +266,11 @@ sub _do_ua
 
     my $lwp = $self->_get_ua(%opts);
 
+    # assigning undef to ENV gives warning in EL5
+    no warnings qw(uninitialized);
     local %ENV = %ENV;
+    use warnings qw(uninitialized);
+
     $self->update_env(\%ENV);
     my $res = $lwp->$method(@$args);
 

--- a/src/main/perl/Kerberos.pm
+++ b/src/main/perl/Kerberos.pm
@@ -772,7 +772,11 @@ foreach my $class (sort keys %GSSAPI_INTERFACE_WRAPPER) {
             my $self = shift;
 
             # Setup local environment
+            # assigning undef to ENV gives warning in EL5
+            no warnings qw(uninitialized);
             local %ENV = %ENV;
+            use warnings qw(uninitialized);
+
             $self->update_env(\%ENV);
 
             my ($status);
@@ -849,7 +853,11 @@ sub _process
     my ($self, $cmd) = @_;
 
     # Setup local environment
+    # assigning undef to ENV gives warning in EL5
+    no warnings qw(uninitialized);
     local %ENV = %ENV;
+    use warnings qw(uninitialized);
+
     $self->update_env(\%ENV);
 
     my $proc = CAF::Process->new($cmd, log => $self);


### PR DESCRIPTION
ncm-download unittests fail on el5 due to these warnings