### PR TITLE
CAF::Application: add methods option_exists() and set_options()

### DIFF
--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -125,7 +125,7 @@ sub username
 
 Returns true if the option exists, false otherwhise. Option can be
 defined either in the application configuration file or on the
-command line (based on AppConfig module).
+command line (based on C<AppConfig> module).
 
 =cut
 
@@ -160,6 +160,28 @@ sub option
     }
 
     return $default;
+}
+
+=pod
+
+=item set_option($opt, $val): SUCCESS
+
+Defines an option and sets its value. If the option was previously
+defined, its value is overwritten. This is a wrapper over C<AppConfig>
+methods to hide the internal implementation of a C<CAF::Application>.
+
+This method always returns SUCCESS.
+
+=cut
+
+sub set_option
+{
+    my ($self, $opt, $val) = @_;
+
+    $self->{'CONFIG'}->define($opt);
+    $self->{'CONFIG'}->set($opt, $val);
+
+    return SUCCESS;
 }
 
 =pod

--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -121,20 +121,45 @@ sub username
 
 =pod
 
+=item option_exists($opt): boolean
+
+Returns true if the option exists, false otherwhise. Option can be
+defined either in the application configuration file or on the
+command line (based on AppConfig module).
+
+=cut
+
+# Check if a configuration option exists
+sub option_exists
+{
+    my ($self, $option) = @_;
+    return $self->{CONFIG}->_exists($option);
+}
+
+=pod
+
 =item option($opt): scalar|undef
 
 Returns the option value coming from the command line and/or
 configuration file. Scalar can be a string, or a reference to a hash
 or an array containing the option's value. option() is a wrapper
-on top of AppConfig->get($opt).
+on top of AppConfig->get($opt). 
+
+If the option doesn't exist, returns C<undef>, except if the C<default>
+argument has been specified: in this case this value is returned but
+the option remains undefined.
 
 =cut
 
 sub option
 {
-    my ($self,$opt) = @_;
+    my ($self, $opt, $default) = @_;
 
-    return $self->{'CONFIG'}->get($opt);
+    if ( $self->option_exists($opt) ) {
+        return $self->{'CONFIG'}->get($opt);
+    }
+
+    return $default;
 }
 
 =pod

--- a/src/test/perl/option.t
+++ b/src/test/perl/option.t
@@ -22,21 +22,20 @@ Readonly my $OPTION_VAL2 => 'value2';
 
 # Check that option_exists() returns true if option exists and false otherwise
 ok(!$this_app->option_exists($OPTION1), "Option $OPTION1 doesn't exist");
-$this_app->{CONFIG}->define($OPTION1);
-$this_app->{CONFIG}->set($OPTION1, $OPTION_VAL1);
+$this_app->set_option($OPTION1, $OPTION_VAL1);
 ok($this_app->option_exists($OPTION1), "Option $OPTION1 defined");
 
-# option() tests
-for my $value ($OPTION_VAL1, $OPTION_VAL2) {
-    $this_app->{CONFIG}->define($OPTION1);
-    $this_app->{CONFIG}->set($OPTION1, $value);
+# option() tests for an existing option
+for my $expected_value ($OPTION_VAL1, $OPTION_VAL2) {
+    $this_app->set_option($OPTION1, $expected_value);
     my $option_value = $this_app->option($OPTION1);
-    is($option_value, $value, "Option has expected value ($value)");
+    is($option_value, $expected_value, "Option has expected value ($expected_value)");
 }
 
 # option() tests for an undefined option
 ok(! defined($this_app->option('undefined_option')), "undef returned when option is undefined (no default value)");
 is($this_app->option('undefined_option', $OPTION_VAL1), $OPTION_VAL1, "default value returned if option is undefined");
+ok(! defined($this_app->option('undefined_option')), "option stays undefined after calling set_option with a default value");
 
 
 done_testing();

--- a/src/test/perl/option.t
+++ b/src/test/perl/option.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+use CAF::Application;
+use Test::Quattor::Object;
+use Readonly;
+
+=pod
+
+=head1 SYNOPSIS
+
+Tests for the C<option> and C<option_exists> methods of C<CAF::Application>.
+
+=cut
+
+our $this_app = CAF::Application->new('option test');
+
+Readonly my $OPTION1 => 'testopt';
+Readonly my $OPTION_VAL1 => 'value1';
+Readonly my $OPTION_VAL2 => 'value2';
+
+
+# Check that option_exists() returns true if option exists and false otherwise
+ok(!$this_app->option_exists($OPTION1), "Option $OPTION1 doesn't exist");
+$this_app->{CONFIG}->define($OPTION1);
+$this_app->{CONFIG}->set($OPTION1, $OPTION_VAL1);
+ok($this_app->option_exists($OPTION1), "Option $OPTION1 defined");
+
+# option() tests
+for my $value ($OPTION_VAL1, $OPTION_VAL2) {
+    $this_app->{CONFIG}->define($OPTION1);
+    $this_app->{CONFIG}->set($OPTION1, $value);
+    my $option_value = $this_app->option($OPTION1);
+    is($option_value, $value, "Option has expected value ($value)");
+}
+
+# option() tests for an undefined option
+ok(! defined($this_app->option('undefined_option')), "undef returned when option is undefined (no default value)");
+is($this_app->option('undefined_option', $OPTION_VAL1), $OPTION_VAL1, "default value returned if option is undefined");
+
+
+done_testing();

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -24,8 +24,6 @@ use mypath;
 use File::Path qw(mkpath rmtree);
 use File::Basename qw(dirname);
 
-$CAF::Object::NoAction = 1;
-
 my $ec_check = $CAF::Path::EC;
 
 my $obj = Test::Quattor::Object->new();


### PR DESCRIPTION
Both methods are wrapper of `AppConfig` methods to avoid exposing `CAF::Application` and `AppConfig` implementation details
- option_exists(): allow to check the existence of a given option
  - Used in option() to avoid the AppConfig error if the option doesn't exist
- set_option(): allow to define an option and its value

Fixes #210 
