### PR TITLE
Path: _get_noaction should try instance noAction method first

### DIFF
--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -124,11 +124,15 @@ sub _get_noaction
         $self->debug(1, $msg, "keeps_state set, noaction is false");
         $noaction = 0;
     } else {
-        $noaction = $CAF::Object::NoAction ? 1 : 0;
+        if ($self->can('noAction')) {
+            $noaction = $self->noAction();
+        } else {
+            $noaction = $CAF::Object::NoAction;
+        }
         $self->debug(1, $msg, "noaction is ", ($noaction ? 'true' : 'false'));
     }
 
-    return $noaction;
+    return $noaction ? 1 : 0;
 }
 
 =item _reset_exception_fail
@@ -252,7 +256,7 @@ sub LC_Check
 {
     my ($self, $function, $args, $opts) = @_;
 
-    my $noaction = $self->_get_noaction($opts->{$KEEPS_STATE});
+    my $noaction = $self->_get_noaction($opts->{$KEEPS_STATE}, $function);
     delete $opts->{$KEEPS_STATE};
 
     # Override noaction passed via opts

--- a/src/test/perl/path.t
+++ b/src/test/perl/path.t
@@ -31,6 +31,10 @@ my $ec_check = $CAF::Path::EC;
 my $obj = Test::Quattor::Object->new();
 
 my $mock = Test::MockModule->new('CAF::Path');
+my $mockobj = Test::MockModule->new('CAF::Object');
+
+# return global value instead of the one set during init
+$mockobj->mock('noAction', sub {return $CAF::Object::NoAction});
 
 
 my $basetest = 'target/test/check';


### PR DESCRIPTION
This is mainly an issue for unittests, but must be fixed due to #243 
For regular CAF usage, the global CAF::Object::NoAction is not changed during runtime; so no issues there.