### PR TITLE
FileWriter: DESTROY: do not close an already closed file

### DIFF
--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -578,7 +578,7 @@ Class destructor. Closes the file, perhaps saving it to disk.
 sub DESTROY
 {
     my $self = shift;
-    $self->close();
+    $self->close() if $self->opened();
     $self->SUPER::DESTROY();
 }
 


### PR DESCRIPTION
Fixes the issue where already/explicitly closed FileWriter instances get re-closed during object destroy, causing a unnecessary verbose message that is very confusing.