### PR TITLE
CAF: minor documentation fixes

### DIFF
--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -583,7 +583,7 @@ matches:
 
 =head1 SEE ALSO
 
-This class inherits from L<CAF::FileWriter>, and thus from
-L<IO::String>.
+This class inherits from C<CAF::FileWriter>, and thus from
+C<IO::String>.
 
 =cut

--- a/src/main/perl/FileEditor.pm
+++ b/src/main/perl/FileEditor.pm
@@ -583,7 +583,7 @@ matches:
 
 =head1 SEE ALSO
 
-This class inherits from L<CAF::FileWriter(3pm)>, and thus from
-L<IO::String(3pm)>.
+This class inherits from L<CAF::FileWriter>, and thus from
+L<IO::String>.
 
 =cut

--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -651,7 +651,7 @@ will be closed automatically when it is destroyed:
 
 =head1 SEE ALSO
 
-This package inherits from L<IO::String(3pm)>. Check its man page to
+This package inherits from C<IO::String>. Check its man page to
 do powerful things with the already printed contents.
 
 =head1 TODO

--- a/src/main/perl/Process.pm
+++ b/src/main/perl/Process.pm
@@ -640,6 +640,6 @@ It will only work with the C<execute> method.
 
 =head1 SEE ALSO
 
-L<LC::Process(8)>
+C<LC::Process>
 
 =cut


### PR DESCRIPTION
Minor documentation fixes some links in FileEditor, FileWriter and Process. As is they build invalid URL's.