### PR TITLE
Process: support search'n'replace and arbitrary function to modify reported commandline

### DIFF
--- a/src/main/perl/RuleBasedEditor.pm
+++ b/src/main/perl/RuleBasedEditor.pm
@@ -897,6 +897,7 @@ sub _updateConfigLine
 
     # Update the matching configuration lines
     if ( $new_line ) {
+        my $correct_new_line = $self->_escape_regexp_string($new_line);
         my $comment = "";
         # For shell variables, add a comment at the end of the line indicating it was edited by Quattor
         # Not done for other formats as comments at the end of the line are not supported in many
@@ -907,7 +908,7 @@ sub _updateConfigLine
         $self->debug(1, "$function_name: checking expected configuration line ($new_line) with pattern ",
                      ">>>$config_param_pattern<<<");
         $self->add_or_replace_lines(qr/^\s*$config_param_pattern/,
-                                    qr/^\s*$new_line$/,
+                                    qr/^\s*$correct_new_line$/,
                                     $new_line . $comment . "\n",
                                     ENDING_OF_FILE,
                                    );

--- a/src/test/perl/application.t
+++ b/src/test/perl/application.t
@@ -6,6 +6,7 @@ use Test::More;
 use testapp;
 
 use Test::MockModule;
+use Test::Quattor::Object;
 use CAF::Application qw($OPTION_CFGFILE);
 
 

--- a/src/test/perl/file_new_open.t
+++ b/src/test/perl/file_new_open.t
@@ -17,6 +17,7 @@ use CAF::FileReader;
 
 use File::Path;
 use File::Temp qw(tempfile);
+use Test::Quattor::Object;
 
 my $testdir = 'target/test/file_new_open';
 mkpath($testdir);

--- a/src/test/perl/fileeditor_positions.t
+++ b/src/test/perl/fileeditor_positions.t
@@ -6,6 +6,7 @@ use lib "$Bin/modules";
 use testapp;
 use CAF::FileEditor;
 use Test::More;
+use Test::Quattor::Object;
 use Carp qw(confess);
 use Fcntl qw(:seek);
 
@@ -22,11 +23,6 @@ my ($log, $str);
 my $this_app = testapp->new ($0, qw (--verbose));
 
 $SIG{__DIE__} = \&confess;
-
-*testapp::error = sub {
-    my $self = shift;
-    $self->{ERROR} = @_;
-};
 
 open ($log, ">", \$str);
 use constant TEXT => <<'EOF';

--- a/src/test/perl/filereader.t
+++ b/src/test/perl/filereader.t
@@ -8,6 +8,7 @@ use testapp;
 use CAF::FileWriter;
 use CAF::FileReader;
 use Test::More;
+use Test::Quattor::Object;
 
 =pod
 

--- a/src/test/perl/history.t
+++ b/src/test/perl/history.t
@@ -9,6 +9,7 @@ use Test::MockModule;
 use LC::Exception qw (SUCCESS);
 use myhistory;
 use object_ok;
+use Test::Quattor::Object;
 
 use CAF::History qw($IDX $ID $TS $REF);
 

--- a/src/test/perl/lock-fork.t
+++ b/src/test/perl/lock-fork.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use CAF::Lock qw(FORCE_IF_STALE FORCE_ALWAYS);
 use Test::MockObject::Extends;
+use Test::Quattor::Object;
 
 use constant LOCK_TEST_DIR => "target/test";
 use constant LOCK_TEST => LOCK_TEST_DIR . "/lock-fork";

--- a/src/test/perl/log.t
+++ b/src/test/perl/log.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::MockModule;
 use LC::Exception qw (SUCCESS);
 use CAF::Log qw($FH $FILENAME $SYSLOG);
+use Test::Quattor::Object;
 
 mkdir('target/test');
 

--- a/src/test/perl/object.t
+++ b/src/test/perl/object.t
@@ -6,6 +6,7 @@ use Test::MockModule;
 use LC::Exception;
 # Test the EXPORT_OK
 use CAF::Object qw(SUCCESS CHANGED throw_error);
+use Test::Quattor::Object;
 
 use FindBin qw($Bin);
 use lib "$Bin/modules";

--- a/src/test/perl/process-streamoutput.t
+++ b/src/test/perl/process-streamoutput.t
@@ -15,6 +15,7 @@ use testapp;
 use CAF::Process;
 use Test::More;
 use Cwd 'abs_path';
+use Test::Quattor::Object;
 
 my $exe = abs_path("$Bin/../resources/stream_output.sh");
 

--- a/src/test/perl/reporter.t
+++ b/src/test/perl/reporter.t
@@ -21,6 +21,8 @@ use Scalar::Util qw(refaddr);
 use Template;
 use version;
 
+use Test::Quattor::Object;
+
 use Readonly;
 Readonly my $EVENTS => 'EVENTS';
 Readonly my $INSTANCES => 'INSTANCES';

--- a/src/test/perl/service-autoload.t
+++ b/src/test/perl/service-autoload.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More;
 use CAF::Service;
 use Test::MockModule;
+use Test::Quattor::Object;
 
 # do not use Test::Quattor for this test
 

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::Quattor;
 use CAF::Service;
 use Test::MockModule;
+use Test::Quattor::Object;
 
 =pod
 

--- a/src/test/perl/textrender.t
+++ b/src/test/perl/textrender.t
@@ -7,6 +7,7 @@ use Test::Quattor;
 use CAF::TextRender qw($YAML_BOOL $YAML_BOOL_PREFIX get_template_instance);
 use Test::MockModule;
 use Cwd;
+use Test::Quattor::Object;
 
 use B qw(svref_2object);
 


### PR DESCRIPTION
Reported commandlines with sensitive data might still be relevant, and simply hiding the whole commandline is often too extreme.  This supports adds a simple way to replace eg passwords on the reported commandline, but leave everything else intact.