### PR TITLE
CAF: documentation fixes

### DIFF
--- a/src/main/perl/Application.pm
+++ b/src/main/perl/Application.pm
@@ -79,8 +79,8 @@ sub name
 
 =item version(): string
 
-Returns the version number as defined in $self->{'VERSION'}, or
-<unknown> if not defined.
+Returns the version number as defined in C<< $self->{'VERSION'} >>, or
+C<< <unknown> >> if not defined.
 
 =cut
 
@@ -142,8 +142,8 @@ sub option_exists
 
 Returns the option value coming from the command line and/or
 configuration file. Scalar can be a string, or a reference to a hash
-or an array containing the option's value. option() is a wrapper
-on top of AppConfig->get($opt). 
+or an array containing the option's value. C<option()> is a wrapper
+on top of C<< AppConfig->get($opt) >>.
 
 If the option doesn't exist, returns C<undef>, except if the C<default>
 argument has been specified: in this case this value is returned but
@@ -167,7 +167,7 @@ sub option
 =item set_option($opt, $val): SUCCESS
 
 Defines an option and sets its value. If the option was previously
-defined, its value is overwritten. This is a wrapper over C<AppConfig>
+defined, its value is overwritten. This is a wrapper over C<AppConfig> 
 methods to hide the internal implementation of a C<CAF::Application>.
 
 This method always returns SUCCESS.

--- a/src/main/perl/Download/LWP.pm
+++ b/src/main/perl/Download/LWP.pm
@@ -123,6 +123,7 @@ Best-effort to handle ssl setup, C<Net::SSL> vs C<IO::Socket::SSL>
 and C<verify_hostname>.
 
 Example usage
+
     ...
     my $ua = $self->_get_ua(%opts);
 
@@ -144,7 +145,7 @@ Options
 
 =item key: the client certificate private key filename
 
-=item ccache: the kerberos crednetial cache
+=item ccache: the kerberos credential cache
 
 =item timeout: set timeout
 

--- a/src/main/perl/FileWriter.pm
+++ b/src/main/perl/FileWriter.pm
@@ -433,7 +433,7 @@ sub noAction
 =item stringify
 
 Returns a string with the contents of the file, so far. It overloads
-C<"">, so it's now possible to do "$fh" and get the contents of the
+C<"">, so it's now possible to do C<$fh> and get the contents of the
 file so far.
 
 (Returns empty string on an already closed file.)
@@ -453,7 +453,7 @@ sub stringify
 =item error, warn, info, verbose, debug, report, log, OK
 
 Convenience methods to access the log/reporter instance that might
-be passed during initialisation and set to C<*$self->{LOG}>.
+be passed during initialisation and set to C<< *$self->{LOG} >>.
 
 =cut
 
@@ -689,11 +689,5 @@ will be closed automatically when it is destroyed:
 
 This package inherits from C<IO::String>. Check its man page to
 do powerful things with the already printed contents.
-
-=head1 TODO
-
-This has became too heavy: in some circumstances, manipulating a file
-involves opening it three times, reading it twice and executing two
-commands. We probably need to drop LC::* and do things in our own way.
 
 =cut

--- a/src/main/perl/Kerberos.pm
+++ b/src/main/perl/Kerberos.pm
@@ -55,7 +55,7 @@ CAF::Kerberos - Class for Kerberos handling using L<GSSAPI>.
 This class handles Kerberos tickets and some
 utitlities like kerberos en/decryption.
 
-To create a new ticket for principal SERVICE/host@REALM
+To create a new ticket for principal C<SERVICE/host@REALM>
 (using default (server) keytab for the TGT), you can use
 
     my $krb = CAF::Kerberos->new(
@@ -540,7 +540,7 @@ sub DESTROY {
 Convert the principal hashref into a principal string.
 
 Optional C<principal> hashref can be passed, if none is provided,
-use the instance C<$self->{principal}>.
+use the instance C<< $self->{principal} >>.
 
 Returns the principal string, undef in case or problem.
 
@@ -842,7 +842,7 @@ use strict 'refs';
 
 =item _process
 
-Run arrayref $cmd via C<CAF::Process->new->output> in updated environment.
+Run arrayref $cmd via C<< CAF::Process->new->output >> in updated environment.
 
 Returns the output (and sets C<< $? >>).
 

--- a/src/main/perl/Log.pm
+++ b/src/main/perl/Log.pm
@@ -140,11 +140,12 @@ If the C<w> option is used and there was a previous
 log file, it is renamed with the extension '.prev'.
 
 Examples:
+
     CAF::Log->new('/foo/bar', 'at'): append, enable timestamp
     CAF::Log->new('/foo/bar', 'w') : truncate logfile, no timestamp
 
 If the filename ends with C<.log>, the C<SYSLOG> attribute is set to
-basename of the file without suffix (relevant for B<CAF::Reporter::syslog>).
+basename of the file without suffix (relevant for C<CAF::Reporter::syslog>).
 
 =cut
 

--- a/src/main/perl/Object.pm
+++ b/src/main/perl/Object.pm
@@ -58,7 +58,7 @@ C<_initialize> (e.g. to avoid troubles when the subclass overloads logic evaluat
 =item new
 
 Creates an empty hash and bless'es it as the new class instance. All arguments are then passed
-to a C<$self->_initialize(@_)> call.
+to a C<< $self->_initialize(@_) >> call.
 When C<_initialize> returns success, the C<NoAction> attribute is set to the value of
 C<CAF::Object::NoAction> if it didn't exist after C<_initialize>.
 If C<_initialize> returns failure, an error is thrown and undef returned.
@@ -127,7 +127,7 @@ sub _initialize
 =item error, warn, info, verbose, debug, report, OK, event
 
 Convenience methods to access the log/reporter instance that might
-be passed during initialisation and set to C<$self->{log}>.
+be passed during initialisation and set to C<< $self->{log} >>.
 
 (When constructing classes via multiple inheritance,
 C<CAF::Reporter> should precede C<CAF::Object> if you want
@@ -157,7 +157,7 @@ logs it with C<verbose> and returns undef.
 
 To be used in subclasses that are not supposed to log/report
 any errors themself when a problem or failure occurs.
-In such classes, all failures should use C<return $self->fail("message");>.
+In such classes, all failures should use C<< return $self->fail("message"); >>.
 
 =cut
 

--- a/src/main/perl/ObjectText.pm
+++ b/src/main/perl/ObjectText.pm
@@ -27,6 +27,7 @@ Define subclass via
     }
 
 And use it via
+
     my $sc = SubClass->new(log => $self);
     print "$sc"; # stringification
 

--- a/src/main/perl/Path.pm
+++ b/src/main/perl/Path.pm
@@ -94,9 +94,10 @@ undef on failure and store the error message in the C<fail> attribute.
 Returns an instance of C<CAF::Object> and C<CAF::Path>.
 This instance is a simple way to use C<CAF::Path> when
 subclassing is not possible. Allowed options are
-C<<log => $logger>> and C<<NoAction => $noaction>>.
+C<< log => $logger >> and C<< NoAction => $noaction >>.
 
 This function is not exported, to be used as e.g.
+
     use CAF::Path;
     ...
     my $cafpath = CAF::Path::mkcafpath(log => $logger);
@@ -141,7 +142,7 @@ sub mkcafpath
 
 =item LC_Check
 
-Execute function C<<LC::Check::<function>>> with arrayref C<$args> and hashref C<$opts>.
+Execute function C<< LC::Check::<function> >> with arrayref C<$args> and hashref C<$opts>.
 
 C<CAF::Object::NoAction> is added to the options, unless C<keeps_state> is set.
 

--- a/src/main/perl/Process.pm
+++ b/src/main/perl/Process.pm
@@ -41,7 +41,7 @@ functions. Commands are logged at the verbose level.
 
 All these methods return the return value of their LC::Process
 equivalent. This is different from the command's exit status, which is
-stored in $?.
+stored in C<$?>.
 
 Please use these functions, and B<do not> use C<``>, C<qx//> or
 C<system>. These functions won't spawn a subshell, and thus are more
@@ -124,6 +124,7 @@ it will reveal (parts of) sensitive data if the order is not correct.
 
 If C<sensitive> is a function reference, the command arrayref is passed
 as only argument, and the stringified return value is reported.
+
     my $replace = sub {
         my $command = shift;
         return join("_", @$command);
@@ -220,7 +221,7 @@ Run C<LC::Process> C<function> with arrayref arguments C<args>.
 C<noaction_value> is is the value to return with C<NoAction>.
 
 C<msg> and C<postmsg> are used to construct log message
-C<<<msg> command: <COMMAND>[ <postmsg>]>>.
+C<< <msg> command: <COMMAND>[ <postmsg>] >>.
 
 =cut
 
@@ -259,7 +260,7 @@ Runs the command, with the options passed at initialization time. If
 running on verbose mode, the exact command line and options are
 logged.
 
-Please, initialize the object with C<log => ''> if you are passing
+Please, initialize the object with C<< log => '' >> if you are passing
 confidential data as an argument to your command.
 
 =back
@@ -348,7 +349,7 @@ the remainder of the output when the process is finished.
 Another option are the process C<arguments>. This is a reference to the
 array of arguments passed to the C<process> function.
 The arguments are passed before the output to the C<process>: e.g.
-if C<arguments =\> [qw(a b)]> is used, the C<process> function is
+if C<< arguments =\> [qw(a b)] >> is used, the C<process> function is
 called like C<process(a,b,$newoutput)> (with C<$newoutput> the
 new streamed output)
 
@@ -649,7 +650,7 @@ sub execute_if_exists
 =head1 COMMON USE CASES
 
 On the next examples, no log is used. If you want your component to
-log the command, just add log => $self to the object creation.
+log the command, just add C<< log => $self >> to the object creation.
 
 =head2 Running a command
 
@@ -722,9 +723,5 @@ it. But please, don't use it without a B<good> reason:
     $cmd->execute();
 
 It will only work with the C<execute> method.
-
-=head1 SEE ALSO
-
-C<LC::Process>
 
 =cut

--- a/src/main/perl/Reporter.pm
+++ b/src/main/perl/Reporter.pm
@@ -232,7 +232,7 @@ filename, but the internal C<$LOGFILE> attribute).
 =item struct
 
 Enable the structured logging type C<struct> (implemented by method
-C< <_struct_<struct> >>).
+C<< _struct_<struct> >>).
 
 If C<struct> is defined but false, structured logging will be disabled.
 
@@ -533,10 +533,10 @@ sub debug
 
 Writes C<@array> as a concatenated string with added newline
 to the log file, if one is setup
-(via C<<config_reporter(logfile => $loginst) >>).
+(via C<< config_reporter(logfile => $loginst) >>).
 
 If the last argument is a hashref and structured logging is enabled
-(via C<<config_reporter(struct => $type) >>), call the structured
+(via C<< config_reporter(struct => $type) >>), call the structured
 logging method with this hashref as argument.
 
 =cut

--- a/src/main/perl/TextRender.pm
+++ b/src/main/perl/TextRender.pm
@@ -129,10 +129,10 @@ JSON format (using C<JSON::XS>) (JSON true and false have to be resp. C<\1> and 
 
 =item yaml
 
-YAML (using C<YAML::XS>) (YAML true and false, either resp. C<$YAML_BOOL->{yes}> and
-C<$YAML_BOOL->{no}>; or the strings C<$YAML_BOOL_PREFIX."true"> and
+YAML (using C<YAML::XS>) (YAML true and false, either resp. C<<$YAML_BOOL->{yes} >> and
+C<< $YAML_BOOL->{no} >>; or the strings C<$YAML_BOOL_PREFIX."true"> and
 C<$YAML_BOOL_PREFIX."false"> (There are known problems with creating hashrefs using the
-C<$YAML_BOOL->{yes}> value for true; Perl seems to mess up the structure when creating
+C<< $YAML_BOOL->{yes} >> value for true; Perl seems to mess up the structure when creating
 the hashrefs))
 
 =item properties


### PR DESCRIPTION
Consists mainly out of code block escaping fixes and correcting 1 typo.