### PR TITLE
Add support for try-restart/condrestart

### DIFF
--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -406,8 +406,12 @@ sub __make_method
     } elsif ($flavour eq 'linux_systemd') {
         return sub {
             my $self = shift;
-            return $self->_logcmd("systemctl", $method,
-                                  map { m/\.(service|target)$/ ? $_ : "$_.service" } @{$self->{services}} );
+            my $ok = 1;
+
+            foreach my $i (@{$self->{services}}) {
+                $ok &&= $self->_logcmd("systemctl", $method, $i =~ m/\.(service|target)$/ ? $i : "$i.service");
+            }
+            return $ok;
         };
     } elsif ($flavour eq 'solaris') {
         return sub {

--- a/src/main/perl/Service.pm
+++ b/src/main/perl/Service.pm
@@ -10,7 +10,7 @@ use Readonly;
 
 Readonly my $DEFAULT_SLEEP => 5;
 Readonly::Array our @FLAVOURS => qw(linux_sysv linux_systemd solaris);
-Readonly::Array my @GENERATED_ACTIONS => qw(start stop restart reload);
+Readonly::Array my @GENERATED_ACTIONS => qw(start stop restart reload condrestart);
 Readonly::Array our @ALL_ACTIONS => (@GENERATED_ACTIONS, 'stop_sleep_start');
 
 # Mapping the methods we expose here to the svcadm operations. We
@@ -18,7 +18,8 @@ Readonly::Array our @ALL_ACTIONS => (@GENERATED_ACTIONS, 'stop_sleep_start');
 Readonly::Hash my %SOLARIS_METHODS => {
     start => 'enable',
     stop => 'disable',
-    restart => 'restart'
+    restart => 'restart',
+    condrestart => 'restart'
 };
 
 our @EXPORT_OK = qw(@FLAVOURS @ALL_ACTIONS os_flavour __make_method);
@@ -38,6 +39,7 @@ platforms
     $srv->stop();
     $srv->start();
     $srv->restart();
+    $srv->condrestart();
     $srv->stop_sleep_start();
 
 Will do the right thing with SystemV Init scripts, Systemd units and

--- a/src/main/perl/ServiceActions.pm
+++ b/src/main/perl/ServiceActions.pm
@@ -7,7 +7,7 @@ use CAF::Object qw(SUCCESS);
 use Readonly;
 
 # to keepin sync with caf_service_actions type in template-library-core quattor/types/component
-Readonly our @SERVICE_ACTIONS => qw(restart reload stop_sleep_start);
+Readonly our @SERVICE_ACTIONS => qw(restart reload stop_sleep_start condrestart);
 
 our @EXPORT_OK = qw(@SERVICE_ACTIONS);
 

--- a/src/test/perl/service-subclass.t
+++ b/src/test/perl/service-subclass.t
@@ -39,7 +39,7 @@ Test avaliable methods
 
 =cut
 
-foreach my $m (qw(start stop restart reload init)) {
+foreach my $m (qw(start stop restart reload condrestart init)) {
     foreach my $fl (@FLAVOURS) {
         my $method = "${m}_${fl}";
         diag "can $method";
@@ -55,7 +55,7 @@ Test all methods + custom init for C<CAF::Service> for linux_sysv
 
 =cut
 
-foreach my $m (qw(start stop restart reload init)) {
+foreach my $m (qw(start stop restart reload condrestart init)) {
     diag "method $m";
     $srv->$m();
     is($command, "service myservice $m", "subclassed service myservice $m works");

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -40,12 +40,14 @@ foreach my $m (@ALL_ACTIONS) {
 foreach my $m (@actions) {
     my $method = "${m}_linux_systemd";
     $srv->$method();
-    ok(get_command("systemctl $m ntpd.service sshd.service"), "systemctl $m works");
+    ok(get_command("systemctl $m ntpd.service"), "systemctl $m works");
 }
 command_history_reset;
 $srv->stop_sleep_start(1);
-ok(command_history_ok(["systemctl stop ntpd.service sshd.service",
-                       "systemctl start ntpd.service sshd.service"
+ok(command_history_ok(["systemctl stop ntpd.service",
+                       "systemctl stop sshd.service",
+                       "systemctl start ntpd.service",
+                       "systemctl start sshd.service"
                        ]), "stop_sleep_start systemctl works");
 
 

--- a/src/test/perl/service.t
+++ b/src/test/perl/service.t
@@ -28,7 +28,7 @@ Test all methods for C<CAF::Service> for linux_systemd
 
 set_service_variant("linux_systemd");
 
-my @actions = qw(start stop restart reload);
+my @actions = qw(start stop restart reload condrestart);
 
 is_deeply(\@ALL_ACTIONS, [@actions, 'stop_sleep_start'], "exported supported actions as expected");
 foreach my $m (@ALL_ACTIONS) {
@@ -60,7 +60,7 @@ Test all methods for C<CAF::Service> for linux_sysv
 
 set_service_variant("linux_sysv");
 
-foreach my $m (qw(start stop restart reload)) {
+foreach my $m (qw(start stop restart reload condrestart)) {
     my $method = "${m}_linux_sysv";
     $srv->$method();
     ok(get_command("service ntpd $m"), "sysv $m works");
@@ -91,6 +91,8 @@ $srv->start_solaris();
 ok(get_command("svcadm -v enable -t ntpd sshd"), "svcadm enable/start works");
 $srv->stop_solaris();
 ok(get_command("svcadm -v disable -t ntpd sshd"), "svcadm disable/stop works");
+$srv->condrestart_solaris();
+ok(get_command("svcadm -v restart -t ntpd sshd"), "svcadm [cond]restart works");
 
 $srv->reload_solaris();
 ok(get_command('svcadm -v refresh ntpd sshd'),

--- a/src/test/perl/serviceactions.t
+++ b/src/test/perl/serviceactions.t
@@ -44,7 +44,8 @@ ok(!@Test::Quattor::command_history, "No commands run before run");
 $sa->run();
 ok(command_history_ok(["systemctl condrestart daemon4.service",
                        "systemctl reload daemon2.service",
-                       "systemctl restart daemon1.service daemon3.service"]),
+                       "systemctl restart daemon1.service",
+                       "systemctl restart daemon3.service"]),
    "run runs expected commands long");
 ok(!$obj->{LOGLATEST}->{ERROR}, "no errors long");
 


### PR DESCRIPTION
Unconditionally bringing up a service is not always the correct thing to do.

I've also changed the systemd variant to operate on one unit at a time, see quattor/configuration-modules-core#1376.