### PR TITLE
workflows: Switch CI action over to our own container image

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -5,40 +5,27 @@ on: [push, pull_request]
 jobs:
   runtests:
     runs-on: ubuntu-latest
-    container: rockylinux:8
+    container:
+      image: ghcr.io/quattor/quattor-test-container:latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Determine hash for caching key
       id: cachekeystep
-      run: echo "pomcachekey=${{ hashFiles('pom.xml') }}" >> $GITHUB_ENV
-    - name: set up dependencies
-      run: |
-        dnf -y install dnf-plugins-core
-        dnf config-manager --set-enabled appstream
-        dnf config-manager --set-enabled powertools
-        dnf -y install epel-release \
-          http://yum.quattor.org/devel/quattor-yum-repo-2-1.noarch.rpm
-        dnf -y install maven perl-Test-Quattor panc libselinux-utils wget perl-Test-Harness
-    - name: set up template library core from git master
-      run: |
-        cd /tmp
-        # install library core in /tmp, tests need it
-        wget -O template-library-core-master.tar.gz https://codeload.github.com/quattor/template-library-core/tar.gz/master
-        tar -xzf template-library-core-master.tar.gz
-        cd -
+      run: echo "pomcachekey=${{ hashFiles('**/pom.xml') }}" >> $GITHUB_ENV
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/m2
         key: ${{ runner.os }}-m2-${{ env.pomcachekey }}
         restore-keys: ${{ runner.os }}-m2-
     - name: run tests
       run: |
+        # make sure it exists before chown
         mkdir -p /tmp/m2
-        useradd -m -s /bin/bash quattor
-        chown -R quattor:quattor . /tmp/m2
-        runuser --preserve-environment --command "source /usr/bin/mvn_test.sh && mvn_test" quattor
+        chown -R quattortest:quattortest . /tmp/m2
+        # we have to run as a non-root user to pass the spma tests
+        # secondly, we first download all maven dependencies and then run the tests because it fails with hanging downloads otherwise.
+        runuser --shell /bin/bash --preserve-environment --command "source /usr/bin/mvn_test.sh && mvn_run \"dependency:resolve-plugins dependency:go-offline $MVN_ARGS\" && mvn_test" quattortest
       env:
-        QUATTOR_TEST_TEMPLATE_LIBRARY_CORE: /tmp/template-library-core-master
         MVN_ARGS: -Dmaven.repo.local=/tmp/m2


### PR DESCRIPTION
Based on quattor/configuration-modules-core#1706.