### PR TITLE
ServiceActions: Unescape daemon names

### DIFF
--- a/src/main/perl/ServiceActions.pm
+++ b/src/main/perl/ServiceActions.pm
@@ -3,6 +3,7 @@
 use parent qw(CAF::Object Exporter);
 use CAF::Service;
 use CAF::Object qw(SUCCESS);
+use EDG::WP4::CCM::Path qw(unescape);
 
 use Readonly;
 
@@ -113,8 +114,9 @@ sub add
     $msg = " $msg" if $msg;
 
     my @acts;
-    foreach my $daemon (sort keys %{$pairs || {}}) {
-        my $action = $pairs->{$daemon};
+    foreach my $escdaemon (sort keys %{$pairs || {}}) {
+        my $daemon = unescape($escdaemon);
+        my $action = $pairs->{$escdaemon};
         if (grep {$_ eq $action} @SERVICE_ACTIONS) {
             $self->{actions}->{$action} ||= {};
             $self->{actions}->{$action}->{$daemon} = 1;

--- a/src/test/perl/serviceactions.t
+++ b/src/test/perl/serviceactions.t
@@ -76,4 +76,9 @@ ok(command_history_ok(["systemctl reload daemon2.service"], ['daemon1']),
    "run runs expected commands wrong (no daemon1)");
 
 
+my $sa4 = CAF::ServiceActions->new(log => $obj);
+$sa4->add({daemon_40instance_2eservice => 'restart'});
+is_deeply($sa4->{actions}, {restart => {'daemon@instance.service' => 1}}, "add correctly unescapes instanced name");
+
+
 done_testing;


### PR DESCRIPTION
This allows for use with templated services e.g. `ssh@mgmt.service` as `@` is an invalid character in a dict key.

Fixes quattor/configuration-modules-core#1672.